### PR TITLE
ci: improve npm ci reliability; add Conventional Commits to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install
         run: |
-          npm ci || (echo "npm ci failed; retrying with clean cache" && rm -rf node_modules package-lock.json && npm ci)
+          npm ci || (echo "npm ci failed; retrying clean install" && rm -rf node_modules package-lock.json && npm install)
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
           cache: 'npm'
 
       - name: Install
-        run: npm install
+        run: |
+          npm ci || (echo "npm ci failed; retrying with clean cache" && rm -rf node_modules package-lock.json && npm ci)
 
       - name: Lint
         run: npm run lint

--- a/README.md
+++ b/README.md
@@ -5,10 +5,19 @@ Initial repository setup.
 After clone: `./scripts/bootstrap.sh` to enable commit hooks.
 
 Docs
+
 - [Architecture](docs/Architecture.md)
 - [Features](docs/Features.md)
 - [User Stories](docs/UserStories.md)
 - [CLI Spec](docs/CLI.md)
 
 ## Roadmap
+
 - [GitHub Project](https://github.com/users/flyingrobots/projects/3)
+
+## Conventional Commits
+
+- Required for PR titles to pass CI (semantic pull request check)
+- Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+- Scope is optional but recommended (e.g., `cli`, `server`, `db`, `web`, `ops`).
+- Example: `feat(cli): add submit command`

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,9 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "*"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -252,6 +255,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@rtsao/scc": {

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "bin": {
     "db8": "./bin/db8.js"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "*"
   }
 }


### PR DESCRIPTION
- CI: use npm ci with clean fallback to avoid rollup optional dep hiccups\n- Docs: add Conventional Commits section to README\n\nThis is the single commit 88723c6 that landed after PR #34 was merged.