### PR TITLE
feat(server): M1 RPC endpoints (submission.create, state)

### DIFF
--- a/server/rpc.js
+++ b/server/rpc.js
@@ -1,5 +1,8 @@
 import express from 'express';
+import crypto from 'node:crypto';
 import { rateLimitStub } from './mw/rate-limit.js';
+import { SubmissionIn } from './schemas.js';
+import { canonicalize, sha256Hex } from './utils.js';
 
 const app = express();
 app.use(express.json());
@@ -8,12 +11,37 @@ app.use(rateLimitStub());
 // Healthcheck
 app.get('/health', (_req, res) => res.json({ ok: true }));
 
-// Placeholder: submission.create
+// In-memory idempotency and submission store (M1 stub)
+const memSubmissions = new Map(); // key -> { id, canonical_sha256 }
+
+// submission.create
 app.post('/rpc/submission.create', (req, res) => {
-  // Zod validation will come later
-  const { client_nonce } = req.body || {};
-  if (!client_nonce) return res.status(400).json({ ok: false, error: 'client_nonce required' });
-  return res.json({ ok: true, submission_id: 'TODO', canonical_sha256: 'TODO' });
+  try {
+    const input = SubmissionIn.parse(req.body);
+    const canon = canonicalize({
+      room_id: input.room_id,
+      round_id: input.round_id,
+      author_id: input.author_id,
+      phase: input.phase,
+      deadline_unix: input.deadline_unix,
+      content: input.content,
+      claims: input.claims,
+      citations: input.citations,
+      client_nonce: input.client_nonce
+    });
+    const canonical_sha256 = sha256Hex(canon);
+
+    const key = `${input.room_id}:${input.round_id}:${input.author_id}:${input.client_nonce}`;
+    if (memSubmissions.has(key)) {
+      const found = memSubmissions.get(key);
+      return res.json({ ok: true, submission_id: found.id, canonical_sha256 });
+    }
+    const submission_id = crypto.randomUUID();
+    memSubmissions.set(key, { id: submission_id, canonical_sha256 });
+    return res.json({ ok: true, submission_id, canonical_sha256 });
+  } catch (err) {
+    return res.status(400).json({ ok: false, error: err?.message || String(err) });
+  }
 });
 
 // Placeholder: vote.continue

--- a/server/schemas.js
+++ b/server/schemas.js
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const Claim = z.object({
+  id: z.string(),
+  text: z.string().min(3),
+  support: z
+    .array(
+      z.object({
+        kind: z.enum(['citation', 'logic', 'data']),
+        ref: z.string()
+      })
+    )
+    .min(1)
+});
+
+export const Citation = z.object({ url: z.string().url(), title: z.string().optional() });
+
+export const SubmissionIn = z.object({
+  room_id: z.string().uuid(),
+  round_id: z.string().uuid(),
+  author_id: z.string().uuid(),
+  phase: z.enum(['OPENING', 'ARGUMENT', 'FINAL']),
+  deadline_unix: z.number().int(),
+  content: z.string().min(1).max(4000),
+  claims: z.array(Claim).min(1).max(5),
+  citations: z.array(Citation).min(2),
+  client_nonce: z.string().min(8),
+  signature_kind: z.enum(['ssh', 'ed25519']).optional(),
+  signature_b64: z.string().optional(),
+  signer_fingerprint: z.string().optional()
+});

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,0 +1,19 @@
+import crypto from 'node:crypto';
+
+export function canonicalize(value) {
+  const seen = new WeakSet();
+  const walk = (v) => {
+    if (v === null || typeof v !== 'object') return v;
+    if (seen.has(v)) throw new Error('Cannot canonicalize circular structure');
+    seen.add(v);
+    if (Array.isArray(v)) return v.map(walk);
+    const out = {};
+    for (const k of Object.keys(v).sort()) out[k] = walk(v[k]);
+    return out;
+  };
+  return JSON.stringify(walk(value));
+}
+
+export function sha256Hex(s) {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}


### PR DESCRIPTION
## Summary
Add minimal server endpoints and tests for M1.

- POST  (Zod-validated)
  - Validates payload (claims/citations limits, etc.)
  - Canonicalizes and returns 
  - Idempotent via  (in-memory map for now)
- GET 
  - Returns an authoritative snapshot stub 

## Details
- Schemas:  (Zod , , )
- Utils:  (, )
- Middleware: reuses existing rate-limit stub
- Tests:  verifies idempotency and canonical hash

## Next
- Wire Supabase RPC once available (replace in-memory store)
- Add deadline enforcement and RLS-backed reads when DB is present

Refs: docs/Architecture.md, docs/Features.md (M1)
