### PR TITLE
feat(server): vote.continue endpoint (idempotent, Zod-validated)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,43 +3,65 @@
 This file gives the coding agent (you) conventions and checkpoints for working in this repo.
 
 Scope
+
 - Applies to all files in this repository.
 - Keep changes small and focused; follow the guardrails below.
 
 Progress tracking
+
 - Primary tracker: GitHub Project “db8 Roadmap”.
-- Use labels and milestones already created (area/*, type/*, priority/*, M1–M7).
+- Use labels and milestones already created (area/_, type/_, priority/\*, M1–M7).
 - When you open PRs, link the corresponding issues and set the milestone.
 
+Pull requests
+
+- Use Markdown in PR bodies (no HTML). Lead with a short Summary and bullet points for Changes, Tests, and Next.
+- Always include issue auto-closures when applicable: “Fixes #<n>”, “Closes #<n>”, or “Partially addresses #<n>”.
+- Set the correct milestone and labels on the PR.
+
+Board hygiene
+
+- Keep statuses accurate on the Project board:
+  - New M1 issues: set Status = “Todo”.
+  - Actively working: set Status = “In Progress”.
+  - PR opened: add label `status/in-review` (and optionally move to an “In Review” column if available).
+  - Merged/Done: set Status = “Done” and close the issue.
+- Add missing issues/PRs to the project when discovered.
+
 Working style
+
 - JavaScript-only across web, server, and CLI. No TypeScript.
 - Validate inputs with Zod at the edges.
 - Keep server and watcher small; heavy work belongs in Supabase (SQL/RPC/RLS) or the worker.
 - Deterministic behavior: prefer stable hashing, canonical JSON, advisory locks.
 
 Guardrails (enforced by repo config)
+
 - Node 20+. See .nvmrc.
 - ESLint + Prettier. See eslint.config.js and .prettierrc.
 - Git hooks for lint-staged and commit message checks.
 - CI runs lint and tests with a real Postgres service.
 
 Test-first checklist (M1)
-1) Write/adjust pgTAP invariants for rooms/rounds/submissions.
-2) Write minimal Vitest tests for canonical JSON and RPC schema validation.
-3) Keep E2E smoke as a placeholder (skip) until routes exist.
+
+1. Write/adjust pgTAP invariants for rooms/rounds/submissions.
+2. Write minimal Vitest tests for canonical JSON and RPC schema validation.
+3. Keep E2E smoke as a placeholder (skip) until routes exist.
 
 Local dev
+
 - Run: `docker compose -f docker-compose.test.yml up -d db`
 - Set env: copy `.env.example` to `.env` and fill values as needed.
 - Prepare hooks: `git config core.hooksPath .githooks && chmod +x .githooks/*`
 
 Project board
+
 - Project name: db8 Roadmap
 - Columns: use the Status field (Todo / In Progress / Done).
 - Add new issues to the project and set Status.
 
 Links
+
 - Features: docs/Features.md
 - Architecture: docs/Architecture.md
 - User stories: docs/UserStories.md
-

--- a/server/schemas.js
+++ b/server/schemas.js
@@ -29,3 +29,11 @@ export const SubmissionIn = z.object({
   signature_b64: z.string().optional(),
   signer_fingerprint: z.string().optional()
 });
+
+export const ContinueVote = z.object({
+  room_id: z.string().uuid(),
+  round_id: z.string().uuid(),
+  voter_id: z.string().uuid(),
+  choice: z.enum(['continue', 'end']),
+  client_nonce: z.string().min(8)
+});

--- a/server/test/rpc.vote_continue.test.js
+++ b/server/test/rpc.vote_continue.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import app from '../rpc.js';
+
+describe('POST /rpc/vote.continue', () => {
+  it('is idempotent by client_nonce', async () => {
+    const body = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      voter_id: '00000000-0000-0000-0000-000000000004',
+      choice: 'continue',
+      client_nonce: 'nonce-xyz'
+    };
+    const r1 = await request(app).post('/rpc/vote.continue').send(body).expect(200);
+    const r2 = await request(app).post('/rpc/vote.continue').send(body).expect(200);
+    expect(r1.body.ok).toBe(true);
+    expect(r2.body.ok).toBe(true);
+    expect(r1.body.vote_id).toEqual(r2.body.vote_id);
+  });
+});


### PR DESCRIPTION
## Summary
Implements the continue vote endpoint with validation and idempotency, matching M1 requirements.

- POST 
  - Zod validates: room_id, round_id, voter_id, choice, client_nonce
  - Idempotent by 
  - Optional DB persistence when  is set, with in-memory fallback
- Tests:  (idempotency)

Fixes #4

## Notes
- Completes the remaining part of #4 (submission.create and /state were delivered in earlier PRs)
- Rate-limiting headers are already added; enforcement remains optional

## Next
- Deadline/phase enforcement and tally logic
- Watcher timers and state enrichment
- Add negative validation tests and rate-limit tests
