### PR TITLE
feat(server): deadline enforcement and validation tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,44 @@ Links
 - Features: docs/Features.md
 - Architecture: docs/Architecture.md
 - User stories: docs/UserStories.md
+
+Operational notes (for future‑you)
+
+- Merge methods
+  - Repo allows Merge and Rebase; Squash is disabled. Use Merge in gh/PR UI unless Rulesets require linear history (then use Rebase).
+  - Auto‑merge: enable per‑PR (UI or `gh pr merge <n> --merge --auto`) after required checks/approvals are green.
+  - Rulesets vs legacy protection: REST `branches/*/protection` 404 is normal if using Rulesets. Ensure required checks match names exactly (`build-test`, `conventional-commits`).
+
+- CI stability (Linux runners)
+  - Rollup native optional dep can fail on `npm ci`. We added:
+    - `optionalDependencies`: `@rollup/rollup-linux-x64-gnu`
+    - `postinstall` guard to install it if missing
+    - CI install fallback to clean `npm install` if `npm ci` flakes
+  - Keep `package-lock.json` committed for `setup-node` cache.
+
+- Runtime configuration
+  - Node 20+ enforced (`.nvmrc`, engines, CI). No TypeScript.
+  - Zod at edges.
+  - `DATABASE_URL` optional. If set, endpoints try DB persistence with in‑memory idempotent fallback.
+  - pgTAP scaffolded; gated via workflow_dispatch or `RUN_PGTAP=1`.
+
+- Project workflow
+  - Fields: Status (Todo/In Progress/Done) and Workflow (Todo/In Progress/In Review/Done).
+  - New milestone issue → Status=Todo, Workflow=Todo.
+  - Active coding → Status=In Progress, Workflow=In Progress.
+  - PR opened → Workflow=In Review (+ label `status/in-review` if filtering helps).
+  - Merged → Status=Done, Workflow=Done; close issue via “Fixes #<n>”.
+
+- Branch & PR conventions
+  - Branch names: `feat/...`, `fix/...`, `chore/...`.
+  - Titles: Conventional Commits (e.g., `feat(server): vote.continue endpoint`).
+  - Labels: `area/*`, `type/*`, `priority/*`; set milestone (M1–M7) and link issues.
+
+- Tests
+  - Local: `npm install && npm test` (Vitest). Skipped E2E placeholders are fine.
+  - DB: `docker compose up -d db`; pgTAP: `db/test/run.sh` when needed.
+
+- Endpoints delivered (M1)
+  - `POST /rpc/submission.create` — Zod, canonicalization, idempotent by `(room, round, author, client_nonce)`, optional DB.
+  - `POST /rpc/vote.continue` — Zod, idempotent by `(round, voter, kind, client_nonce)`, optional DB.
+  - `GET /state` — stub snapshot.

--- a/docs/CLI-Quickstart.md
+++ b/docs/CLI-Quickstart.md
@@ -1,0 +1,47 @@
+# CLI Quickstart
+
+The db8 CLI is currently provided as a local binary in this repo. It targets Node 20+.
+
+## Install (local)
+
+```
+# from the repo root
+npm link   # makes `db8` available on your PATH
+```
+
+## Identity helpers
+
+```
+db8 whoami          # prints room/participant if configured
+```
+
+## Room state
+
+```
+db8 room status     # prints current phase/timers snapshot from /state
+```
+
+## Draft & submit
+
+```
+db8 draft open      # creates ./db8/round-0/anon/draft.json
+$EDITOR db8/round-0/anon/draft.json
+
+db8 draft validate  # runs Zod locally; prints canonical SHA256
+
+db8 submit          # canonicalizes and POSTs to /rpc/submission.create
+```
+
+Flags & env
+
+- Global flags: `--room`, `--participant`, `--json`, `--nonce`
+- Env vars:
+  - `DB8_API_URL` (default: http://localhost:3000)
+  - `DB8_ROOM_ID`, `DB8_PARTICIPANT_ID`, `DB8_JWT` for authenticated flows
+
+Notes
+
+- Idempotency: submissions and votes de‑duplicate by client nonce.
+- Provenance: `--sign` (SSH) lands in a later milestone; server accepts unsigned in M1.
+
+For full command spec, see docs/CLI.md.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,0 +1,72 @@
+# Getting Started
+
+This guide helps you run db8 locally and try the CLI and server.
+
+## Prerequisites
+
+- Node 20+
+- Docker (for local Postgres) if you want DB persistence
+
+## Clone & bootstrap
+
+```
+git clone https://github.com/flyingrobots/db8.git
+cd db8
+npm install
+./scripts/bootstrap.sh   # enables commit hooks (optional for contributors)
+```
+
+## Run a local DB (optional)
+
+```
+npm run dev:db      # starts Postgres 16 on localhost:54329
+```
+
+Set `DATABASE_URL=postgresql://postgres:test@localhost:54329/db8` in your shell if you want the server to persist submissions/votes. Without it, the server uses in‑memory storage with idempotency.
+
+## Start the server
+
+```
+node server/rpc.js   # listens on :3000
+```
+
+Endpoints:
+
+- `GET /state` — returns `{ ok:true, rounds:[], submissions:[] }` (stub)
+- `POST /rpc/submission.create` — accepts a validated submission and returns `{ ok, submission_id, canonical_sha256 }`
+- `POST /rpc/vote.continue` — idempotent continue vote; returns `{ ok, vote_id }`
+
+## CLI quickstart (local)
+
+The CLI is provided as a local binary in this repo under `bin/db8.js`.
+
+```
+npm link         # optional: makes `db8` available on your PATH
+db8 whoami       # prints identity (from ~/.db8/session.json if present)
+db8 room status  # fetches /state (set DB8_API_URL if not localhost)
+```
+
+Draft & submit flow (demo)
+
+```
+# Create a draft for local round 0 and participant anon
+db8 draft open
+# Edit the file printed (./db8/round-0/anon/draft.json)
+db8 draft validate
+db8 submit   # requires DB8_ROOM_ID, DB8_PARTICIPANT_ID, DB8_JWT if server enforces auth
+```
+
+Environment variables
+
+- `DB8_API_URL` (default: http://localhost:3000)
+- `DB8_ROOM_ID`, `DB8_PARTICIPANT_ID`, `DB8_JWT` — for authenticated flows (not required for the stub server)
+
+## Troubleshooting
+
+- Rollup native dependency error on Linux CI runners (optional info for contributors): this repo includes an `optionalDependencies` entry for `@rollup/rollup-linux-x64-gnu` and a `postinstall` guard to avoid test failures on GH Actions.
+
+## Next steps
+
+- Read the architecture: docs/Architecture.md
+- Explore features & user stories: docs/Features.md, docs/UserStories.md
+- CLI reference/spec: docs/CLI.md

--- a/server/test/rpc.submission_deadline.test.js
+++ b/server/test/rpc.submission_deadline.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import app from '../rpc.js';
+
+describe('POST /rpc/submission.create (deadline)', () => {
+  it('rejects submissions after deadline', async () => {
+    const past = Math.floor(Date.now() / 1000) - 10;
+    const body = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      author_id: '00000000-0000-0000-0000-000000000003',
+      phase: 'OPENING',
+      deadline_unix: past,
+      content: 'Hello world',
+      claims: [{ id: 'c1', text: 'Valid claim', support: [{ kind: 'logic', ref: 'r1' }] }],
+      citations: [{ url: 'https://example.com' }, { url: 'https://example.org' }],
+      client_nonce: 'deadline-test-1'
+    };
+    const r = await request(app).post('/rpc/submission.create').send(body);
+    expect(r.status).toBe(400);
+    expect(r.body.ok).toBe(false);
+    expect(r.body.error).toBe('deadline_passed');
+  });
+});

--- a/server/test/rpc.submission_validation.test.js
+++ b/server/test/rpc.submission_validation.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import app from '../rpc.js';
+
+describe('POST /rpc/submission.create (validation)', () => {
+  it('rejects submissions with fewer than 2 citations', async () => {
+    const body = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      author_id: '00000000-0000-0000-0000-000000000003',
+      phase: 'OPENING',
+      deadline_unix: 0,
+      content: 'Hello world',
+      claims: [{ id: 'c1', text: 'Valid claim', support: [{ kind: 'logic', ref: 'r1' }] }],
+      citations: [{ url: 'https://example.com' }],
+      client_nonce: 'validation-test-1'
+    };
+    const r = await request(app).post('/rpc/submission.create').send(body);
+    expect(r.status).toBe(400);
+    expect(r.body.ok).toBe(false);
+    expect(String(r.body.error)).toMatch(/citations/i);
+  });
+});


### PR DESCRIPTION
## Summary
Enforce submission deadline and add negative validation tests. Optional rate-limit enforcement toggle.

- submission.create: rejects when  is set (>0) and passed ().
- Tests: deadline past (400), <2 citations (400 due to Zod).
- Rate limit: middleware can enforce 429 when  (still default off).

Partially addresses #1/#2 (validation & guards). No DB RLS yet.

## Next
- Phase/round window enforcement and tally.
- Watcher timers (SSE/WS) and /state enrichment.
- Supabase RPC integration for persistence and uniqueness.
