### PR TITLE
feat(web): Room page polish with Zod validation and inline errors

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.3.0",
-        "tailwindcss": "^3.4.13"
+        "tailwindcss": "^3.4.13",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2415,6 +2416,15 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "postcss": "^8.4.33",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "zod": "^3.25.76",
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.4.13"
   }


### PR DESCRIPTION
Summary\n- Polishes Room page UX: validates input with Zod, shows inline error/success, and disables submit while busy.\n\nChanges\n- Add zod as web dependency.\n- Add client-side schema validation to submit.\n- Persist participant/JWT locally for convenience.\n- Replace alerts with inline messages.\n\nTests\n- Lint and Vitest pass.\n\nNext\n- Wire transcript rendering once submissions surface in /state.\n- Add claim/citation editors with client-side helpers.