### PR TITLE
feat(server): expose DB transcripts in /state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
           DATABASE_URL: postgresql://postgres:test@localhost:54329/db8
         run: npm test
 
+      - name: Tests (Postgres RPC integration)
+        if: ${{ vars.RUN_PGTAP == '1' || github.event.inputs.run_pgtap == '1' }}
+        env:
+          RUN_PGTAP: '1'
+          DATABASE_URL: postgresql://postgres:test@localhost:54329/db8
+          DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:54329/db8
+        run: npx vitest run server/test/rpc.db.postgres.test.js
+
       - name: pgTAP (optional)
         if: ${{ vars.RUN_PGTAP == '1' || github.event.inputs.run_pgtap == '1' }}
         env:

--- a/server/test/rpc.db.postgres.test.js
+++ b/server/test/rpc.db.postgres.test.js
@@ -1,0 +1,97 @@
+import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Pool } from 'pg';
+import app, { __setDbPool } from '../rpc.js';
+import { canonicalize, sha256Hex } from '../utils.js';
+
+const shouldRun = process.env.RUN_PGTAP === '1' || process.env.DB8_TEST_PG === '1';
+const dbUrl = process.env.DB8_TEST_DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8';
+
+const suite = shouldRun ? describe : describe.skip;
+
+suite('Postgres-backed RPC integration', () => {
+  let pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: dbUrl });
+    __setDbPool(pool);
+
+    const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
+    const rpcSql = fs.readFileSync(path.resolve('db/rpc.sql'), 'utf8');
+    await pool.query(schemaSql);
+    await pool.query(rpcSql);
+
+    await pool.query(
+      `insert into rooms (id, title)
+       values ('00000000-0000-0000-0000-000000000001', 'Local Demo Room')
+       on conflict (id) do nothing`
+    );
+    await pool.query(
+      `insert into rounds (id, room_id, idx, phase, submit_deadline_unix)
+       values ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 0, 'submit', 0)
+       on conflict (id) do nothing`
+    );
+  });
+
+  afterAll(async () => {
+    __setDbPool(null);
+    await pool?.end?.();
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE submissions, votes RESTART IDENTITY CASCADE;');
+  });
+
+  it('persists submissions through submission_upsert', async () => {
+    const body = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      author_id: '00000000-0000-0000-0000-000000000003',
+      phase: 'OPENING',
+      deadline_unix: 0,
+      content: 'Hello from pg',
+      claims: [{ id: 'c1', text: 'Claim', support: [{ kind: 'logic', ref: 'a' }] }],
+      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      client_nonce: 'pg-nonce-1234'
+    };
+    const canon = canonicalize(body);
+    const expectedHash = sha256Hex(canon);
+
+    const first = await request(app).post('/rpc/submission.create').send(body).expect(200);
+    const second = await request(app).post('/rpc/submission.create').send(body).expect(200);
+
+    expect(first.body.ok).toBe(true);
+    expect(first.body.canonical_sha256).toEqual(expectedHash);
+    expect(second.body.submission_id).toEqual(first.body.submission_id);
+    expect(first.body.note).toBeUndefined();
+
+    const rows = await pool.query('select canonical_sha256 from submissions where id = $1', [
+      first.body.submission_id
+    ]);
+    expect(rows.rows[0]?.canonical_sha256).toEqual(expectedHash);
+  });
+
+  it('persists continue votes through vote_submit', async () => {
+    const body = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      voter_id: '00000000-0000-0000-0000-000000000004',
+      choice: 'continue',
+      client_nonce: 'pg-vote-1234'
+    };
+
+    const first = await request(app).post('/rpc/vote.continue').send(body).expect(200);
+    const second = await request(app).post('/rpc/vote.continue').send(body).expect(200);
+
+    expect(first.body.ok).toBe(true);
+    expect(second.body.vote_id).toEqual(first.body.vote_id);
+    expect(first.body.note).toBeUndefined();
+
+    const rows = await pool.query('select ballot from votes where id = $1', [first.body.vote_id]);
+    const raw = rows.rows[0]?.ballot;
+    const ballot = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    expect(ballot?.choice).toBe('continue');
+  });
+});

--- a/server/test/state.enrichment.test.js
+++ b/server/test/state.enrichment.test.js
@@ -9,6 +9,7 @@ describe('GET /state enrichment', () => {
     expect(r.body.room_id).toBe('roomA');
     expect(typeof r.body.round.submit_deadline_unix).toBe('number');
     expect(r.body.round.continue_tally).toEqual({ yes: 0, no: 0 });
+    expect(Array.isArray(r.body.round.transcript)).toBe(true);
   });
 
   it('updates tally when votes are cast', async () => {
@@ -36,5 +37,6 @@ describe('GET /state enrichment', () => {
       .expect(200);
     const after = await request(app).get(`/state?room_id=${ROOM_UUID}`).expect(200);
     expect(after.body.round.continue_tally).toEqual({ yes: 1, no: 1 });
+    expect(Array.isArray(after.body.round.transcript)).toBe(true);
   });
 });

--- a/web/app/room/[roomId]/page.jsx
+++ b/web/app/room/[roomId]/page.jsx
@@ -103,6 +103,7 @@ export default function RoomPage({ params }) {
   const remaining = Math.max(0, (endsAt || 0) - now);
   const canSubmit =
     state?.ok && state?.round?.phase === 'submit' && isUUID(roomId) && isUUID(participant);
+  const transcript = Array.isArray(state?.round?.transcript) ? state.round.transcript : [];
 
   // Persist small fields locally for convenience
   useEffect(() => {
@@ -282,14 +283,41 @@ export default function RoomPage({ params }) {
             </div>
           </CardContent>
         </Card>
-      ) : (
-        <Card>
-          <CardContent className="p-5 space-y-2">
+      ) : null}
+
+      <Card>
+        <CardContent className="p-5 space-y-3">
+          <div className="flex items-center justify-between">
             <div className="text-lg font-semibold">Transcript</div>
-            <div className="text-sm text-muted">Stub — submissions listing to be wired later.</div>
-          </CardContent>
-        </Card>
-      )}
+            <Badge variant="outline">{transcript.length} entries</Badge>
+          </div>
+          {transcript.length === 0 ? (
+            <p className="text-sm text-muted">No submissions yet.</p>
+          ) : (
+            <ul className="space-y-3">
+              {transcript.map((entry) => (
+                <li
+                  key={entry.submission_id}
+                  className="rounded border border-border p-3 space-y-2"
+                >
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="font-mono text-[11px]">{entry.author_id}</span>
+                    {entry.submitted_at ? (
+                      <time dateTime={new Date(entry.submitted_at * 1000).toISOString()}>
+                        {new Date(entry.submitted_at * 1000).toLocaleTimeString()}
+                      </time>
+                    ) : null}
+                  </div>
+                  <p className="whitespace-pre-line text-sm leading-relaxed">{entry.content}</p>
+                  <p className="text-[11px] text-muted-foreground font-mono">
+                    sha256: {entry.canonical_sha256}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
     </main>
   );
 }

--- a/web/app/spectate/[roomId]/page.jsx
+++ b/web/app/spectate/[roomId]/page.jsx
@@ -1,5 +1,5 @@
 'use client';
-import { use } from 'react';
+import { use, useEffect, useState } from 'react';
 import ThemeToggle from '@/components/theme-toggle';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
@@ -7,6 +7,31 @@ import { Card, CardContent } from '@/components/ui/card';
 export default function SpectatorPage({ params }) {
   const resolvedParams = typeof params?.then === 'function' ? use(params) : params;
   const roomId = resolvedParams?.roomId || 'demo';
+  const [state, setState] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const r = await fetch(
+          `${process.env.NEXT_PUBLIC_DB8_API_URL || 'http://localhost:3000'}/state?room_id=${encodeURIComponent(roomId)}`
+        );
+        const j = await r.json().catch(() => ({}));
+        if (!cancelled) setState(j);
+      } catch {
+        /* ignore */
+      }
+    }
+    if (roomId) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [roomId]);
+
+  const phase = state?.round?.phase || 'submit';
+  const roundIdx = state?.round?.idx ?? '-';
+  const tally = state?.round?.continue_tally || { yes: 0, no: 0 };
+  const transcript = Array.isArray(state?.round?.transcript) ? state.round.transcript : [];
   return (
     <main className="max-w-6xl mx-auto p-6 space-y-6">
       <header className="flex items-center justify-between">
@@ -22,10 +47,46 @@ export default function SpectatorPage({ params }) {
       <Card>
         <CardContent className="p-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Badge variant="success">Phase: PUBLISHED</Badge>
-            <Badge>Round 2</Badge>
+            <Badge variant={phase === 'published' ? 'success' : 'default'}>Phase: {phase}</Badge>
+            <Badge>Round {roundIdx}</Badge>
+            <Badge variant="outline">yes {tally.yes}</Badge>
+            <Badge variant="outline">no {tally.no}</Badge>
           </div>
           <div className="font-mono text-lg">--s</div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-5 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-lg font-semibold">Transcript</div>
+            <Badge variant="outline">{transcript.length} entries</Badge>
+          </div>
+          {transcript.length === 0 ? (
+            <p className="text-sm text-muted">No submissions yet.</p>
+          ) : (
+            <ul className="space-y-3">
+              {transcript.map((entry) => (
+                <li
+                  key={entry.submission_id}
+                  className="rounded border border-border p-3 space-y-2"
+                >
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="font-mono text-[11px]">{entry.author_id}</span>
+                    {entry.submitted_at ? (
+                      <time dateTime={new Date(entry.submitted_at * 1000).toISOString()}>
+                        {new Date(entry.submitted_at * 1000).toLocaleTimeString()}
+                      </time>
+                    ) : null}
+                  </div>
+                  <p className="whitespace-pre-line text-sm leading-relaxed">{entry.content}</p>
+                  <p className="text-[11px] text-muted-foreground font-mono">
+                    sha256: {entry.canonical_sha256}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
         </CardContent>
       </Card>
     </main>


### PR DESCRIPTION
Summary
- return the active round, tally, and transcript from Postgres when /state runs with DATABASE_URL.
- keep the in-memory fallback deterministic and surface transcript data for demo rooms.

Changes
- call submission_upsert/vote_submit and expand /state to hydrate round + transcript from view_current_round/view_continue_tally/submissions.
- add stubbed and live Postgres Vitest suites plus CI job that runs the live DB tests when RUN_PGTAP (or run_pgtap) is enabled.
- render transcripts on the Room and Spectator pages, showing authors, timestamps, and canonical hashes.

Tests
- `npm test`
- `RUN_PGTAP=1 DB8_TEST_DATABASE_URL=postgresql://postgres:test@localhost:54329/db8 npm test`

Next
- stream transcript deltas over /events or a polling diff so the web UI updates live.
- promote the Postgres suite in CI once runtime stabilizes; document workflow triggers for contributors.

Closes #49
Closes #50
