### PR TITLE
ci: run Postgres RPC suite every build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         run: npm test
 
       - name: Tests (Postgres RPC integration)
-        if: ${{ vars.RUN_PGTAP == '1' || github.event.inputs.run_pgtap == '1' }}
         env:
           RUN_PGTAP: '1'
           DATABASE_URL: postgresql://postgres:test@localhost:54329/db8


### PR DESCRIPTION
Summary
- always run the live Postgres Vitest suite (rpc.db.postgres.test.js) in CI so DB paths stay covered.

Changes
- remove the RUN_PGTAP gating on the workflow step; reuse existing PG service and env vars to execute the suite each build.

Tests
- `npm test`

Next
- ensure contributors know docker Postgres is required locally for the full suite (docs update optional).
