### PR TITLE
feat(cli): add submit --dry-run mode

### DIFF
--- a/docs/CLI-Quickstart.md
+++ b/docs/CLI-Quickstart.md
@@ -30,6 +30,7 @@ $EDITOR db8/round-0/anon/draft.json
 db8 draft validate  # runs Zod locally; prints canonical SHA256
 
 db8 submit          # canonicalizes and POSTs to /rpc/submission.create
+db8 submit --dry-run  # prints canonical SHA + nonce without sending to the server
 ```
 
 Flags & env

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,11 +1,13 @@
 # CLI Specification (db8)
 
 Name & Install
+
 - Name: db8
 - Install: npm i -g db8 (Node 20+)
 - Entrypoint: bin/db8.js (ESM)
 
 Files & Locations
+
 - Config: ~/.db8/config.json
 - Session: ~/.db8/session.json (room-scoped JWT; expires)
 - Drafts: ./db8/round-<idx>/<anon>/draft.json
@@ -13,6 +15,7 @@ Files & Locations
 - Cache (read-only): ~/.db8/cache/ (fetched sources by hash)
 
 Environment Variables (override config)
+
 - DB8_API_URL
 - DB8_ROOM_ID
 - DB8_PARTICIPANT_ID
@@ -21,6 +24,7 @@ Environment Variables (override config)
 - DB8_SSH_CERT (optional, ~/.ssh/id_ed25519-cert.pub)
 
 Exit Codes
+
 - 0 ok
 - 2 validation failed (Zod)
 - 3 auth/session error
@@ -31,6 +35,7 @@ Exit Codes
 - 8 not found / bad id
 
 Global Flags
+
 - --room <uuid>
 - --participant <uuid>
 - --json
@@ -42,6 +47,7 @@ Global Flags
 Commands (MVP + near-term)
 
 Auth & Session
+
 - db8 login
   - Device-code or magic-link to obtain room-scoped JWT
   - Writes ~/.db8/session.json
@@ -51,6 +57,7 @@ Auth & Session
   - Prints room, participant, JWT exp, SSH fingerprint (if found)
 
 Room State
+
 - db8 room status
   - Shows topic, phase, round idx, submit deadline, vote window
   - --json dumps the raw /state snapshot
@@ -59,40 +66,46 @@ Room State
   - --json emits event JSON (one per line)
 
 Draft & Submit
+
 - db8 draft open
   - Creates/opens draft.json template for current round/participant
 - db8 draft validate
   - Zod-validate draft; print canonical SHA256
 - db8 submit
   - Canonicalize, optionally SSH-sign, POST submission.create
-  - Options: --sign, --cert <path>, --nonce <id>
+  - Options: --sign, --cert <path>, --nonce <id>, --dry-run
 - db8 resubmit
   - Same as submit with a fresh nonce; server bumps version
 - db8 withdraw
   - Mark last submission withdrawn before deadline (local guard)
 
 Research Helpers (optional)
+
 - db8 cite add <url>
   - Fetch → cache → write citation block into draft.json
 - db8 cite list
   - List citations in draft and surface duplicates / disallowed domains
 
 Voting
+
 - db8 vote continue <continue|end>
   - Idempotent (client nonce)
 - db8 vote final --approve <id,id,...> [--rank <id,id,...>]
 
 Journal & Verify
+
 - db8 journal pull [--round <idx>]
   - Downloads signed journal artifacts for room/round
 - db8 journal verify [--round <idx>]
   - Verifies round.chain.sig and per-submission signatures
 
 Agent QoL (batch)
+
 - db8 agent run <script.js>
   - Runs an agent loop that listens, drafts, and submits with auto-signing
 
 RPC Mapping
+
 - login: POST /auth/device → /auth/exchange
 - room status: GET /state?room_id
 - room watch: WS /events?room_id (SSE alt)
@@ -104,35 +117,41 @@ RPC Mapping
 - journal verify: local
 
 Headers & Provenance
+
 - Authorization: Bearer <JWT>
 - X-DB8-Client-Nonce: <id> (also in body)
 - If --sign: attach ssh_sig (+ cert optional)
 
 CLI UX Rules
+
 - Default human-readable; --json returns exact RPC/event payloads
 - Only login is interactive; --non-interactive fails instead of prompting
 - Spinners only for network waits
 - Crisp errors + exit codes; --json adds {code, message, data?}
 
 Sample Flows
+
 - Fresh user: login → room status → draft open → validate → submit → watch → vote continue
 - Agent with SSH: login → draft → submit --sign → watch --json
 - Journal verify: pull → verify (print OK summary)
 
 Zod Contracts (client mirror)
+
 - SubmissionIn includes client_nonce and optional signature fields and matches server contracts
 
 Config (~/.db8/config.json)
+
 - Contains api_url, default profile, profiles with room/participant and SSH key paths
 
 Non-goals (for now)
+
 - No live server drafts
 - No scraping beyond cite add
 - No long-running daemon (watch exits unless --reconnect)
 
 Test Targets
+
 - Deterministic canonical hash
 - Idempotent submit with identical nonce returns same submission_id
 - Non-interactive fails on missing session/room
 - Provenance signing errors map to exit code 6 (stub during unit tests)
-

--- a/server/test/cli.submit.test.js
+++ b/server/test/cli.submit.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile as _execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+
+const execFile = promisify(_execFile);
+
+function cliBin() {
+  return path.join(process.cwd(), 'bin', 'db8.js');
+}
+
+const ROOM_ID = '00000000-0000-0000-0000-000000000001';
+const PARTICIPANT_ID = '00000000-0000-0000-0000-000000000002';
+async function writeDraft(baseDir, content) {
+  const draftDir = path.join(baseDir, 'db8', 'round-0', 'anon');
+  await fs.mkdir(draftDir, { recursive: true });
+  const draftPath = path.join(draftDir, 'draft.json');
+  const draft = {
+    phase: 'OPENING',
+    deadline_unix: 0,
+    content,
+    claims: [
+      {
+        id: 'c1',
+        text: 'Claim text',
+        support: [{ kind: 'logic', ref: 'support-1' }]
+      }
+    ],
+    citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }]
+  };
+  await fs.writeFile(draftPath, JSON.stringify(draft, null, 2));
+  return draftPath;
+}
+
+describe('CLI submit --dry-run', () => {
+  let tmpDir;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'db8-cli-submit-'));
+  });
+
+  afterAll(async () => {
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits canonical hash without performing network call', async () => {
+    const draftPath = await writeDraft(tmpDir, 'Hello dry run');
+    const nonce = 'nonce-dryrun-12345';
+
+    const validate = await execFile(
+      'node',
+      [
+        cliBin(),
+        'draft',
+        'validate',
+        '--path',
+        draftPath,
+        '--room',
+        ROOM_ID,
+        '--participant',
+        PARTICIPANT_ID,
+        '--nonce',
+        nonce,
+        '--json'
+      ],
+      { cwd: tmpDir }
+    );
+    const validateJson = JSON.parse(validate.stdout.trim());
+
+    const { stdout } = await execFile(
+      'node',
+      [
+        cliBin(),
+        'submit',
+        '--dry-run',
+        '--room',
+        ROOM_ID,
+        '--participant',
+        PARTICIPANT_ID,
+        '--path',
+        draftPath,
+        '--nonce',
+        nonce,
+        '--round',
+        '0',
+        '--json'
+      ],
+      { cwd: tmpDir }
+    );
+    const result = JSON.parse(stdout.trim());
+    expect(result.ok).toBe(true);
+    expect(result.dry_run).toBe(true);
+    expect(result.canonical_sha256).toEqual(validateJson.canonical_sha256);
+    expect(result.client_nonce).toEqual(nonce);
+  });
+});


### PR DESCRIPTION
Summary
- add a --dry-run flag to `db8 submit` that only prints canonical_sha256 + client nonce.
- skip the network call in dry-run mode so no JWT is required.
- add a Vitest covering draft validate + submit dry-run equivalence and document the flag.

Changes
- allow submit to skip the JWT requirement when `--dry-run` is present.
- output canonical hash + nonce in either human or JSON mode without POSTing.
- new `cli.submit.test.js` ensures dry run matches `draft validate` output.
- docs updated (CLI quickstart/spec) to mention the flag.

Tests
- `npm test`
