### PR TITLE
feat(cli): add device-code login stub

### DIFF
--- a/docs/CLI-Quickstart.md
+++ b/docs/CLI-Quickstart.md
@@ -12,6 +12,8 @@ npm link   # makes `db8` available on your PATH
 ## Identity helpers
 
 ```
+db8 login --device-code --room <uuid>  # interactive device-code stub (prompts for JWT)
+db8 login --room <uuid> --participant <uuid> --jwt <token>
 db8 whoami          # prints room/participant if configured
 ```
 

--- a/server/test/cli.login.test.js
+++ b/server/test/cli.login.test.js
@@ -1,4 +1,4 @@
-import { execFile as _execFile } from 'node:child_process';
+import { execFile as _execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import os from 'node:os';
 import path from 'node:path';
@@ -46,5 +46,37 @@ describe('CLI login + whoami (session file)', () => {
     expect(j2.ok).toBe(true);
     expect(j2.room_id).toBe(room);
     expect(j2.participant_id).toBe(participant);
+  });
+
+  test('device-code flow writes session after prompting for JWT', async () => {
+    const HOME = await mkHome();
+    const env = { ...process.env, HOME };
+    const room = '00000000-0000-0000-0000-0000000000dd';
+    const participant = '00000000-0000-0000-0000-0000000000ee';
+    const jwt = 'device.jwt.token';
+
+    const child = spawn(
+      'node',
+      [cli().bin, 'login', '--device-code', '--room', room, '--participant', participant, '--json'],
+      { env }
+    );
+
+    // Provide JWT when prompted
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    child.stdin.write(`${jwt}\n`);
+
+    const exitCode = await new Promise((resolve, reject) => {
+      child.on('close', (code) => resolve(code));
+      child.on('error', reject);
+    });
+    expect(exitCode).toBe(0);
+
+    const sessPath = path.join(HOME, '.db8', 'session.json');
+    const sess = JSON.parse(await fs.readFile(sessPath, 'utf8'));
+    expect(sess.room_id).toBe(room);
+    expect(sess.participant_id).toBe(participant);
+    expect(sess.jwt).toBe(jwt);
+    expect(sess.login_via).toBe('device_code');
+    expect(sess.device_code).toBeDefined();
   });
 });


### PR DESCRIPTION
Summary
- add a `--device-code` flag to `db8 login` that provides a device code and collects JWT interactively.
- allow non-interactive runs to supply `--participant`/`--jwt` while still marking the session as device_code.
- update quickstart docs and extend CLI tests to cover the new flow.

Changes
- when --device-code is given and no JWT is available, prompt for participant/JWT via readline.
- persist session metadata (`login_via`, `device_code`) and relax JWT requirement for dry-run.
- new Vitest spawns the CLI, feeds JWT, and asserts session state; docs updated for both login paths.

Tests
- `npm test`
