### PR TITLE
feat(cli): make room watch reconnect and respect quiet

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -62,8 +62,8 @@ Room State
   - Shows topic, phase, round idx, submit deadline, vote window
   - --json dumps the raw /state snapshot
 - db8 room watch
-  - Tails phase changes + timers (WS/SSE)
-  - --json emits event JSON (one per line)
+  - Streams timer/events (SSE) and reconnects with backoff
+  - Emits one JSON object per line; use --quiet to suppress reconnect logs
 
 Draft & Submit
 

--- a/server/test/cli.room.watch.test.js
+++ b/server/test/cli.room.watch.test.js
@@ -50,4 +50,90 @@ describe('CLI room watch (SSE)', () => {
     expect(j.t).toBe('timer');
     expect(j.room_id).toBe(room);
   }, 15000);
+
+  test('reconnects after connection drop and emits JSON lines', async () => {
+    let connections = 0;
+    const reconnectServer = http.createServer((req, res) => {
+      if (req.url.startsWith('/events')) {
+        connections += 1;
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive'
+        });
+        const payload = JSON.stringify({ t: 'timer', count: connections });
+        res.write(`data: ${payload}\n\n`);
+        setTimeout(() => {
+          res.end();
+        }, 40);
+      } else {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise((resolve) => reconnectServer.listen(0, resolve));
+    const port = reconnectServer.address().port;
+    const env = {
+      ...process.env,
+      DB8_API_URL: `http://127.0.0.1:${port}`,
+      DB8_ROOM_ID: 'room-reconnect',
+      DB8_CLI_TEST_MAX_EVENTS: '2'
+    };
+
+    const child = spawn('node', [cliBin(), 'room', 'watch'], { env });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    const exitCode = await new Promise((resolve, reject) => {
+      child.on('close', (code) => resolve(code));
+      child.on('error', reject);
+    });
+    await new Promise((resolve) => reconnectServer.close(resolve));
+
+    expect(exitCode).toBe(0);
+    const lines = stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed[0].t).toBe('timer');
+    expect(parsed[1].count).toBeGreaterThanOrEqual(2);
+    expect(connections).toBeGreaterThanOrEqual(2);
+  }, 15000);
+
+  test('quiet suppresses reconnect messages', async () => {
+    const quietServer = http.createServer((req, res) => {
+      if (req.url.startsWith('/events')) {
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache'
+        });
+        res.write(`data: ${JSON.stringify({ t: 'timer', count: 1 })}\n\n`);
+        setTimeout(() => res.end(), 40);
+      } else {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise((resolve) => quietServer.listen(0, resolve));
+    const port = quietServer.address().port;
+    const env = {
+      ...process.env,
+      DB8_API_URL: `http://127.0.0.1:${port}`,
+      DB8_ROOM_ID: 'room-quiet',
+      DB8_CLI_TEST_MAX_EVENTS: '1'
+    };
+    const child = spawn('node', [cliBin(), 'room', 'watch', '--quiet'], { env });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    await new Promise((resolve, reject) => {
+      child.on('close', resolve);
+      child.on('error', reject);
+    });
+    await new Promise((resolve) => quietServer.close(resolve));
+
+    expect(stderr.trim()).toBe('');
+  }, 15000);
 });


### PR DESCRIPTION
Summary
- stream events as JSON lines and automatically reconnect with exponential backoff.
- suppress reconnect logs when --quiet is passed.
- add CLI tests for reconnect behaviour and quiet mode, plus docs update.

Changes
- rewrite `room watch` to loop with SSE reconnect + optional quiet logging; supports test-only max event env.
- always emit JSON per event, reset backoff on success, and handle SIGINT cleanly.
- extend CLI room watch tests to cover JSON output, reconnection, and quiet stderr behavior; docs/CLI.md updated.

Tests
- `npm test`
