### PR TITLE
feat(flagging): submission flagging flow

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -60,4 +60,17 @@ CREATE TABLE IF NOT EXISTS votes (
 
 CREATE INDEX IF NOT EXISTS idx_votes_room_round_kind ON votes (room_id, round_id, kind);
 
+-- Submission flags: allow participants/moderators/viewers to report content
+CREATE TABLE IF NOT EXISTS submission_flags (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  submission_id  uuid        NOT NULL REFERENCES submissions(id) ON DELETE CASCADE,
+  reporter_id    text        NOT NULL,
+  reporter_role  text        NOT NULL,
+  reason         text        NOT NULL DEFAULT '',
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (submission_id, reporter_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_submission_flags_submission ON submission_flags (submission_id);
+
 -- Future M1/M2: rooms/rounds tables, RLS policies, and RPCs

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,3 +6,22 @@ services:
       POSTGRES_DB: db8
     ports: ["54329:5432"]
 
+  tests:
+    image: node:20-bookworm
+    working_dir: /app
+    depends_on:
+      db:
+        condition: service_started
+    environment:
+      NODE_ENV: test
+      DATABASE_URL: postgresql://postgres:test@db:5432/db8
+      DB8_TEST_DATABASE_URL: postgresql://postgres:test@db:5432/db8
+    volumes:
+      - ./:/app
+      - node_modules_linux:/app/node_modules
+      - node_modules_web_linux:/app/web/node_modules
+    command: ["tail", "-f", "/dev/null"]
+
+volumes:
+  node_modules_linux:
+  node_modules_web_linux:

--- a/docs/LocalDB.md
+++ b/docs/LocalDB.md
@@ -44,11 +44,19 @@ PGURL=postgresql://postgres:test@localhost:54329/db8 ./db/test/run.sh
 
 ## Run Node Tests with DB Backed Path
 
-Export `DATABASE_URL` so the server code uses the DB path, then run tests:
+`npm test` launches Vitest through Docker compose so the suite always sees a Postgres sidecar:
 
 ```
-export DATABASE_URL=postgresql://postgres:test@localhost:54329/db8
 npm test
+```
+
+The command brings up the `db` container (if needed), applies `db/schema.sql` and `db/rpc.sql`, executes tests from the `tests` service against `postgresql://postgres:test@db:5432/db8`, and then tears the stack down automatically when the run finishes.
+
+Need to bypass Docker for debugging? Set `CI=true` or call the inner script directly:
+
+```
+CI=true npm test
+npm run test:inner
 ```
 
 ## Run the Server with DB

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.52.3",
         "express": "^5.1.0",
         "zod": "^3.25.76"
       },
@@ -33,7 +34,7 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "^4.52.3",
         "pg": "^8.13.1"
       }
     },
@@ -249,6 +250,34 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.52.2",
       "cpu": [
@@ -261,10 +290,178 @@
         "darwin"
       ]
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
+    "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
-      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
       "cpu": [
         "x64"
       ],
@@ -272,6 +469,90 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -2202,6 +2483,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -4030,6 +4326,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/router": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "postinstall": "node -e \"try{require('@rollup/rollup-linux-x64-gnu');process.exit(0)}catch(e){process.exit(1)}\" || npm i @rollup/rollup-linux-x64-gnu@latest || true",
     "lint": "eslint .",
     "format": "prettier -w .",
-    "test": "vitest run",
+    "test": "if [ \"$CI\" = \"true\" ]; then npm run test:inner; else npm run test:docker; fi",
+    "test:docker": "bash ./scripts/test-docker.sh",
+    "test:prepare-db": "node ./scripts/prepare-db.js",
+    "test:inner": "vitest run",
     "typecheck": "echo 'No TypeScript. ✅'",
     "bootstrap": "bash ./scripts/bootstrap.sh",
     "dev:db": "docker compose up -d db && sleep 2 && echo 'DB on :54329'",
@@ -44,7 +47,7 @@
     "zod": "^3.25.76"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.52.2",
+    "@rollup/rollup-linux-x64-gnu": "^4.52.3",
     "pg": "^8.13.1"
   },
   "bin": {

--- a/scripts/prepare-db.js
+++ b/scripts/prepare-db.js
@@ -1,0 +1,49 @@
+import { readFile, access } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const { Client } = pg;
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function applyFile(client, filePath) {
+  const sql = await readFile(filePath, 'utf8');
+  if (sql.trim().length === 0) return;
+  await client.query(sql);
+}
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8';
+  const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const schemaPath = path.join(rootDir, 'db', 'schema.sql');
+  const rpcPath = path.join(rootDir, 'db', 'rpc.sql');
+
+  const client = new Client({ connectionString: dbUrl });
+  await client.connect();
+  try {
+    if (await fileExists(schemaPath)) await applyFile(client, schemaPath);
+    if (await fileExists(rpcPath)) await applyFile(client, rpcPath);
+  } finally {
+    await client.end();
+  }
+}
+
+main()
+  .then(() => {
+    if (process.env.DB8_TEST_OUTPUT !== 'quiet') {
+      console.warn('database prepared');
+    }
+  })
+  .catch((err) => {
+    console.error('database preparation failed', err);
+    process.exitCode = 1;
+  });

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.test.yml}
+
+docker compose -f "$COMPOSE_FILE" up -d db >/dev/null
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down --remove-orphans >/dev/null
+}
+
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE_FILE" run --rm tests bash -lc 'npm ci && npm run test:prepare-db && npm run test:inner'

--- a/server/rpc.js
+++ b/server/rpc.js
@@ -2,7 +2,7 @@ import express from 'express';
 import crypto from 'node:crypto';
 import pg from 'pg';
 import { rateLimitStub } from './mw/rate-limit.js';
-import { SubmissionIn, ContinueVote } from './schemas.js';
+import { SubmissionIn, ContinueVote, SubmissionFlag } from './schemas.js';
 import { canonicalize, sha256Hex } from './utils.js';
 import { loadConfig } from './config/config-builder.js';
 
@@ -31,7 +31,9 @@ export function __setDbPool(pool) {
 app.get('/health', (_req, res) => res.json({ ok: true }));
 
 // In-memory idempotency and submission store (M1 stub / fallback)
-const memSubmissions = new Map(); // key -> { id, canonical_sha256, content, author_id }
+const memSubmissions = new Map(); // key -> { id, canonical_sha256, content, author_id, room_id }
+const memSubmissionIndex = new Map(); // submission_id -> { room_id }
+const memFlags = new Map(); // submission_id -> Map(reporter_id -> { role, reason, created_at })
 
 // submission.create
 app.post('/rpc/submission.create', (req, res) => {
@@ -87,8 +89,10 @@ app.post('/rpc/submission.create', (req, res) => {
               id: submission_id,
               canonical_sha256,
               content: input.content,
-              author_id: input.author_id
+              author_id: input.author_id,
+              room_id: input.room_id
             });
+            memSubmissionIndex.set(submission_id, { room_id: input.room_id });
           }
           return res.json({
             ok: true,
@@ -108,8 +112,10 @@ app.post('/rpc/submission.create', (req, res) => {
       id: submission_id,
       canonical_sha256,
       content: input.content,
-      author_id: input.author_id
+      author_id: input.author_id,
+      room_id: input.room_id
     });
+    memSubmissionIndex.set(submission_id, { room_id: input.room_id });
     return res.json({ ok: true, submission_id, canonical_sha256 });
   } catch (err) {
     return res.status(400).json({ ok: false, error: err?.message || String(err) });
@@ -175,6 +181,65 @@ app.post('/rpc/vote.continue', (req, res) => {
   }
 });
 
+// submission.flag
+app.post('/rpc/submission.flag', async (req, res) => {
+  try {
+    const input = SubmissionFlag.parse(req.body);
+    const cleanReason = (input.reason || '').trim();
+    if (db) {
+      try {
+        const result = await db.query(
+          `with upsert as (
+             insert into submission_flags (submission_id, reporter_id, reporter_role, reason)
+             values ($1, $2, $3, $4)
+             on conflict (submission_id, reporter_id)
+             do update set reporter_role = excluded.reporter_role,
+                           reason = excluded.reason,
+                           created_at = now()
+             returning submission_id
+           )
+           select submission_id,
+                  (select count(*) from submission_flags where submission_id = $1) as flag_count
+             from upsert`,
+          [input.submission_id, input.reporter_id, input.reporter_role, cleanReason]
+        );
+        const count = Number(result.rows?.[0]?.flag_count || 0);
+        return res.json({ ok: true, flag_count: count });
+      } catch (e) {
+        if (e?.code === '23503') {
+          return res.status(404).json({ ok: false, error: 'submission_not_found' });
+        }
+        if (e?.code === '23505') {
+          return res.status(200).json({ ok: true, note: 'duplicate_flag' });
+        }
+        // fall back to in-memory store if DB is unreachable or other errors occur
+        const details =
+          e?.message ||
+          (Array.isArray(e?.errors) ? e.errors.map((err) => err.message).join('; ') : String(e));
+        console.warn('submission.flag db error, falling back to memory', details);
+      }
+    }
+
+    if (!memSubmissionIndex.has(input.submission_id)) {
+      return res.status(404).json({ ok: false, error: 'submission_not_found' });
+    }
+    const existing = memFlags.get(input.submission_id) || new Map();
+    const duplicate = existing.has(input.reporter_id);
+    existing.set(input.reporter_id, {
+      reporter_id: input.reporter_id,
+      reporter_role: input.reporter_role,
+      reason: cleanReason,
+      created_at: Math.floor(Date.now() / 1000)
+    });
+    memFlags.set(input.submission_id, existing);
+    const payload = { ok: true, flag_count: existing.size };
+    if (duplicate) payload.note = 'duplicate_flag';
+    return res.json(payload);
+  } catch (err) {
+    return res.status(400).json({ ok: false, error: err?.message || String(err) });
+  }
+});
+
 // In-memory room/round state and simple time-based transitions
 const memRooms = new Map(); // room_id -> { round: { idx, phase, submit_deadline_unix, published_at_unix?, continue_vote_close_unix? } }
 const SUBMIT_WINDOW_SEC = config.submitWindowSec;
@@ -234,10 +299,28 @@ app.get('/state', async (req, res) => {
             [roomId, roundRow.round_id]
           ),
           db.query(
-            `select id, author_id, content, canonical_sha256, submitted_at
-               from submissions
-              where round_id = $1
-              order by submitted_at asc nulls last, id asc`,
+            `select s.id,
+                    s.author_id,
+                    s.content,
+                    s.canonical_sha256,
+                    s.submitted_at,
+                    coalesce(f.flag_count, 0) as flag_count,
+                    coalesce(f.flag_details, '[]'::jsonb) as flag_details
+               from submissions s
+               left join (
+                 select submission_id,
+                        count(*) as flag_count,
+                        jsonb_agg(jsonb_build_object(
+                          'reporter_id', reporter_id,
+                          'reporter_role', reporter_role,
+                          'reason', reason,
+                          'created_at', extract(epoch from created_at)::bigint
+                        ) order by created_at desc) as flag_details
+                   from submission_flags
+                  group by submission_id
+               ) f on f.submission_id = s.id
+              where s.round_id = $1
+              order by s.submitted_at asc nulls last, s.id asc`,
             [roundRow.round_id]
           )
         ]);
@@ -247,8 +330,13 @@ app.get('/state', async (req, res) => {
           author_id: row.author_id,
           content: row.content,
           canonical_sha256: row.canonical_sha256,
-          submitted_at: row.submitted_at ? Math.floor(row.submitted_at.getTime() / 1000) : null
+          submitted_at: row.submitted_at ? Math.floor(row.submitted_at.getTime() / 1000) : null,
+          flag_count: Number(row.flag_count || 0),
+          flags: Array.isArray(row.flag_details) ? row.flag_details : []
         }));
+        const flagged = transcript
+          .filter((entry) => entry.flag_count > 0)
+          .map((entry) => ({ submission_id: entry.submission_id, flag_count: entry.flag_count }));
         return res.json({
           ok: true,
           room_id: roomId,
@@ -263,7 +351,8 @@ app.get('/state', async (req, res) => {
               no: Number(tallyRow.no || 0)
             },
             transcript
-          }
+          },
+          flags: flagged
         });
       }
     } catch {
@@ -275,17 +364,34 @@ app.get('/state', async (req, res) => {
   const tally = memVoteTotals.get(roomId) || { yes: 0, no: 0 };
   const transcript = Array.from(memSubmissions.entries())
     .filter(([key]) => key.startsWith(`${roomId}:`))
-    .map(([, value]) => ({
-      submission_id: value.id,
-      author_id: value.author_id,
-      content: value.content,
-      canonical_sha256: value.canonical_sha256,
-      submitted_at: null
-    }));
+    .map(([, value]) => {
+      const flags = memFlags.get(value.id);
+      const flagEntries = flags
+        ? Array.from(flags.entries()).map(([, detail]) => ({
+            reporter_id: detail.reporter_id,
+            reporter_role: detail.reporter_role,
+            reason: detail.reason,
+            created_at: detail.created_at
+          }))
+        : [];
+      return {
+        submission_id: value.id,
+        author_id: value.author_id,
+        content: value.content,
+        canonical_sha256: value.canonical_sha256,
+        submitted_at: null,
+        flag_count: flagEntries.length,
+        flags: flagEntries
+      };
+    });
+  const flagged = transcript
+    .filter((entry) => entry.flag_count > 0)
+    .map((entry) => ({ submission_id: entry.submission_id, flag_count: entry.flag_count }));
   return res.json({
     ok: true,
     room_id: roomId,
-    round: { ...round, continue_tally: tally, transcript }
+    round: { ...round, continue_tally: tally, transcript },
+    flags: flagged
   });
 });
 

--- a/server/schemas.js
+++ b/server/schemas.js
@@ -37,3 +37,13 @@ export const ContinueVote = z.object({
   choice: z.enum(['continue', 'end']),
   client_nonce: z.string().min(8)
 });
+
+export const SubmissionFlag = z.object({
+  submission_id: z.string().uuid(),
+  reporter_id: z.string().min(1),
+  reporter_role: z
+    .enum(['participant', 'moderator', 'fact_checker', 'viewer', 'system'])
+    .optional()
+    .default('participant'),
+  reason: z.string().max(500).optional().default('')
+});

--- a/server/test/cli.flag.test.js
+++ b/server/test/cli.flag.test.js
@@ -1,0 +1,75 @@
+import http from 'node:http';
+import { execFile as _execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import request from 'supertest';
+import app, { __setDbPool } from '../rpc.js';
+
+const execFile = promisify(_execFile);
+
+function cliBin() {
+  return path.join(process.cwd(), 'bin', 'db8.js');
+}
+
+describe('CLI flag submission', () => {
+  let server;
+  let url;
+  const room = '00000000-0000-0000-0000-00000000f100';
+  const round = '00000000-0000-0000-0000-00000000f101';
+  const author = '00000000-0000-0000-0000-00000000f102';
+  const participant = '00000000-0000-0000-0000-00000000f103';
+
+  beforeAll(async () => {
+    __setDbPool(null);
+    server = http.createServer(app);
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+    url = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  test('flags a submission and reports flag count', async () => {
+    const submissionPayload = {
+      room_id: room,
+      round_id: round,
+      author_id: author,
+      phase: 'OPENING',
+      deadline_unix: 0,
+      content: 'CLI flag content',
+      claims: [
+        {
+          id: 'c1',
+          text: 'Claim',
+          support: [{ kind: 'logic', ref: 'a' }]
+        }
+      ],
+      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      client_nonce: 'nonce-cli-flag'
+    };
+
+    const createRes = await request(url)
+      .post('/rpc/submission.create')
+      .send(submissionPayload)
+      .expect(200);
+    const submissionId = createRes.body.submission_id;
+
+    const env = {
+      ...process.env,
+      DB8_API_URL: url,
+      DB8_ROOM_ID: room,
+      DB8_PARTICIPANT_ID: participant,
+      DB8_CLI_TEST_MAX_EVENTS: '0'
+    };
+
+    const { stdout } = await execFile(
+      'node',
+      [cliBin(), 'flag', 'submission', '--submission', submissionId, '--reason', 'offensive'],
+      { env }
+    );
+
+    expect(stdout.trim()).toMatch(/flag recorded/);
+  });
+});

--- a/server/test/rpc.submission_flag.test.js
+++ b/server/test/rpc.submission_flag.test.js
@@ -1,0 +1,81 @@
+import request from 'supertest';
+import app, { __setDbPool } from '../rpc.js';
+
+const ROOM_ID = '00000000-0000-0000-0000-00000000f001';
+const ROUND_ID = '00000000-0000-0000-0000-00000000f002';
+const AUTHOR_ID = '00000000-0000-0000-0000-00000000f003';
+
+describe('POST /rpc/submission.flag', () => {
+  beforeAll(() => {
+    __setDbPool(null);
+  });
+
+  it('allows flagging submissions and returns flag count (memory path)', async () => {
+    const submission = {
+      room_id: ROOM_ID,
+      round_id: ROUND_ID,
+      author_id: AUTHOR_ID,
+      phase: 'OPENING',
+      deadline_unix: 0,
+      content: 'Test content',
+      claims: [
+        {
+          id: 'c1',
+          text: 'Claim',
+          support: [{ kind: 'logic', ref: 'a' }]
+        }
+      ],
+      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      client_nonce: 'nonce-flag-1'
+    };
+
+    const submissionRes = await request(app)
+      .post('/rpc/submission.create')
+      .send(submission)
+      .expect(200);
+    expect(submissionRes.body.ok).toBe(true);
+    const submissionId = submissionRes.body.submission_id;
+    expect(submissionId).toBeTruthy();
+
+    const flagPayload = {
+      submission_id: submissionId,
+      reporter_id: '00000000-0000-0000-0000-00000000f010',
+      reporter_role: 'participant',
+      reason: 'inappropriate'
+    };
+
+    const flagRes = await request(app).post('/rpc/submission.flag').send(flagPayload);
+    expect(flagRes.status).toBe(200);
+    expect(flagRes.body.ok).toBe(true);
+    expect(flagRes.body.flag_count).toBe(1);
+
+    // duplicate flag from same reporter should not increment count
+    const flagResDuplicate = await request(app)
+      .post('/rpc/submission.flag')
+      .send(flagPayload)
+      .expect(200);
+    expect(flagResDuplicate.body.ok).toBe(true);
+    expect(flagResDuplicate.body.note).toBe('duplicate_flag');
+
+    const flagResSecond = await request(app)
+      .post('/rpc/submission.flag')
+      .send({
+        submission_id: submissionId,
+        reporter_id: '00000000-0000-0000-0000-00000000f011',
+        reporter_role: 'moderator'
+      })
+      .expect(200);
+    expect(flagResSecond.body.flag_count).toBe(2);
+  });
+
+  it('returns error when submission is missing', async () => {
+    const res = await request(app).post('/rpc/submission.flag').send({
+      submission_id: '00000000-0000-0000-0000-00000000ffff',
+      reporter_id: '00000000-0000-0000-0000-00000000aaaa',
+      reporter_role: 'viewer'
+    });
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('submission_not_found');
+  });
+});


### PR DESCRIPTION
Summary
- add submission flagging path end-to-end (schema, RPC, CLI)

Changes
- create submission_flags table and enrich /rpc endpoints + /state output
- add CLI command \"db8 flag submission\" with validation and integration tests
- run npm test via docker compose harness with auto teardown and DB prep script

Tests
- npm test
- CI=true npm test

Next
- consider switching CI to exercise the compose-backed test harness so host and CI flows are identical
