### PR TITLE
feat(room): server RPC + CLI create (M1)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,50 @@
+name: build-test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: build-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: ghcr.io/library/postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: db8
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d db8"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Prepare DB schema/RPC
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
+          DB8_TEST_OUTPUT: quiet
+        run: npm run test:prepare-db
+
+      - name: Run tests (vitest)
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
+          DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
+          CI: true
+        run: npm run test:inner
+

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 25
     services:
       postgres:
-        image: ghcr.io/library/postgres:16-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: db8
@@ -47,4 +47,3 @@ jobs:
           DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
           CI: true
         run: npm run test:inner
-

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,10 @@
 name: build-test
 
-on:
+'on':
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,3 +283,19 @@ Operational/CI:
   - Phase contract alignment (done).
 - M2 will deliver:
   - JCS canonicalization (RFC 8785), server-issued nonces, SSH/Ed25519 provenance, server checkpoint signatures, journals, CLI verify.
+
+## Agent Log — 2025-10-02
+
+Summary
+
+- Resolved conflicts and merged DB-backed SSE `/events` (LISTEN/NOTIFY) after review on #83.
+- Addressed feedback sprint (#84): removed duplicate postinstall, collapsed duplicated SQL CTEs, improved SSE test timing/logging, consolidated watcher teardown, expanded SSE docs, and marked checklist complete.
+- Implemented secure read path for submissions+flags under RLS via `submissions_with_flags_view`; `/state` now consumes views only. Opened and merged #85.
+- Enabled RLS for `submission_flags` and added read-only policy (visible only post-publish). Marked the view as `SECURITY BARRIER`.
+- Opened/updated roadmap issues and synced the Project board.
+
+Next (M1 wrap)
+
+- Ensure all server DB reads are via views under RLS.
+- Wire watcher usage/documentation as a first-class dev/prod component.
+- Begin M2 preparation (JCS + nonces) once M1 is green.

--- a/bin/db8.js
+++ b/bin/db8.js
@@ -508,7 +508,7 @@ async function main() {
     case 'room:create': {
       // Create a room via API
       const topic = args.topic || args.t;
-      if (!topic || typeof topic !== 'string' || topic.length < 3) {
+      if (typeof topic !== 'string' || Array.from(topic).length < 3) {
         printerr('room create requires --topic <string> (min 3 chars)');
         return EXIT.VALIDATION;
       }
@@ -523,8 +523,8 @@ async function main() {
       }
       if (args['submit-minutes'] !== undefined) {
         const m = Number(args['submit-minutes']);
-        if (!Number.isInteger(m) || m < 0 || m > 1440) {
-          printerr('--submit-minutes must be an integer between 0 and 1440');
+        if (!Number.isInteger(m) || m < 1 || m > 1440) {
+          printerr('--submit-minutes must be an integer between 1 and 1440');
           return EXIT.VALIDATION;
         }
         cfg.submit_minutes = m;
@@ -532,7 +532,7 @@ async function main() {
       const payload = {
         topic,
         ...(Object.keys(cfg).length ? { cfg } : {}),
-        client_nonce: String(args.nonce || randomNonce())
+        client_nonce: args.nonce || randomNonce()
       };
       const url = `${apiUrl.replace(/\/$/, '')}/rpc/room.create`;
       try {

--- a/bin/db8.js
+++ b/bin/db8.js
@@ -513,9 +513,27 @@ async function main() {
         return EXIT.VALIDATION;
       }
       const cfg = {};
-      if (args.participants) cfg.participant_count = Number(args.participants);
-      if (args['submit-minutes']) cfg.submit_minutes = Number(args['submit-minutes']);
-      const payload = { topic, cfg, client_nonce: String(args.nonce || randomNonce()) };
+      if (args.participants !== undefined) {
+        const n = Number(args.participants);
+        if (!Number.isInteger(n) || n < 1 || n > 64) {
+          printerr('--participants must be an integer between 1 and 64');
+          return EXIT.VALIDATION;
+        }
+        cfg.participant_count = n;
+      }
+      if (args['submit-minutes'] !== undefined) {
+        const m = Number(args['submit-minutes']);
+        if (!Number.isInteger(m) || m < 0 || m > 1440) {
+          printerr('--submit-minutes must be an integer between 0 and 1440');
+          return EXIT.VALIDATION;
+        }
+        cfg.submit_minutes = m;
+      }
+      const payload = {
+        topic,
+        ...(Object.keys(cfg).length ? { cfg } : {}),
+        client_nonce: String(args.nonce || randomNonce())
+      };
       const url = `${apiUrl.replace(/\/$/, '')}/rpc/room.create`;
       try {
         const res = await fetch(url, {

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -38,7 +38,11 @@ M2 — Provenance & Journaling
 M3 — Fact-Checking & Verify Phase
 
 - Fact-check worker stubs; mark submissions verified/rejected with reasons.
-- UI affordances to show verification status before publish.
+- Quorum-based fact-checking (FP-20250928) — Approved
+  - Per-checker fact_check_verdicts with RLS and indexes (#86)
+  - RPCs for verdict submit and quorum finalize rules (#87, #88)
+  - Confidence heuristic exposed via research view (#89)
+- UI affordances to show verification status and quorum confidence before publish.
 - Realtime verify status changes.
 
 M4 — Votes, Continue/Final, and Publish Flow

--- a/docs/feature-proposals/accepted/FP-20250928-fact-checking-quorum.md
+++ b/docs/feature-proposals/accepted/FP-20250928-fact-checking-quorum.md
@@ -1,9 +1,35 @@
 ---
 id: FP-20250928-fact-checking-quorum
-status: Draft
+status: Accepted
 authors: James Ross <james@flyingrobots.dev>
 date: 2025-09-28
-related-issues: []
+related-issues: [#81, #86, #87, #88, #89]
+
+## Implementation Plan (Accepted)
+
+Milestone: M3 — Fact-Checking & Verify
+
+- Database (area/db)
+  - fact_check_verdicts table (per-checker rows), indexes, RLS
+  - Aggregation view: quorum confidence heuristic and counts, exposed for datasets
+  - pgTAP invariants for schema, RLS, and aggregation correctness
+
+- RPCs (area/server, area/db)
+  - fact_check.submit (idempotent per submission/checker)
+  - quorum finalize/aggregate or automatic compute at thresholds
+
+- Worker (area/worker)
+  - Aggregator job to compute/store quorum results when thresholds met
+
+- Web (area/web)
+  - Surface verification status per submission and quorum confidence indicator
+
+- CLI (area/cli)
+  - Optional: inspector to print quorum stats for a round
+
+Tracking
+
+- Issues will be linked here once created.
 ---
 
 # Quorum-Based Fact-Checking With Confidence Heuristic

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -4,176 +4,73 @@ Please complete every item in this list. When you finish an item, update this do
 
 # checklist
 
-- [x] package.json 54-54: WHAT THE HELL? Duplicate postinstall field!
+- [ ] In bin/db8.js around lines 509 to 537, the payload currently includes
+      participant and submit-minutes values without validating them (which allows
+      NaN/null/0 into the request). Validate args.participants and
+      args['submit-minutes'] before adding to cfg: parse them to numbers, ensure they
+      are finite integers and within sensible ranges (e.g. participants is an integer
 
-You have postinstall defined TWICE in this file (line 11 and line 54). The second one at line 54 is a duplicate top-level field that will OVERRIDE the one in scripts. This is completely broken JSON structure that will cause undefined behavior.
+  > = 1, submit-minutes is an integer >= 0), and if validation fails print the same
+  > validation error/usage and return EXIT.VALIDATION; only add fields to cfg when
+  > validated, and omit the entire cfg block from the payload if it remains empty.
+  > Also keep returning EXIT.VALIDATION on bad inputs rather than sending the
+  > request.
 
-DELETE line 54 immediately. This is embarrassingly sloppy.
+- [ ] In server/rpc.js around lines 184 to 211, the room.create handler falls back to
+      an in-memory path on DB error but does not expose the DB error message like
+      submission.create does; declare let dbError = null before the DB call, capture
+      the caught DB error into dbError inside the inner catch block, and then include
+      db_error: dbError?.message || String(dbError) in the fallback JSON response
+      (e.g., res.json({ ok: true, room_id, note: 'db_fallback', db_error: ... })) so
+      the pattern matches submission.create.
 
-- "postinstall": "node -e \"try{require('@rollup/rollup-linux-x64-gnu');process.exit(0)}catch(e){process.exit(1)}\" || npm i @rollup/rollup-linux-x64-gnu@latest || true"
+- [ ] In server/rpc.js around lines 197-199, the empty catch block currently swallows
+      all database errors; update it to catch the error into a variable and log the
+      error before falling back to the in-memory path. Use the module's existing
+      logger (or console.error if none) to log a clear contextual message and the
+      error object (stack) so DB failures are observable in production, then let the
+      code continue to the memory fallback as intended.
 
-- [x] db/rpc.sql (1)
-      120-156: Stop duplicating the CTE circus.
+- [ ] In server/rpc.js around lines 201 to 207, the in-memory fallback ignores
+      client_nonce causing non-idempotent room creation; add a memRoomNonces map
+      (declare it at the top with other in-memory stores) and change this block to:
+      check if client_nonce exists in memRoomNonces and if so return the existing
+      room_id and same response; if not, generate the room_id, initialize memRooms as
+      before, then set memRoomNonces.set(client_nonce, room_id) before returning,
+      ensuring repeated requests with the same nonce return the original room.
 
-You copy-pasted the due/tallied/winners CTE stack twice in the same function. The next change to tally semantics is guaranteed to rot because someone will touch one branch and forget the other. Collapse this mess into a single data-modifying CTE so we compute tallies once, update losers, and insert winners off the same dataset.
+- [ ] In server/rpc.js around lines 204–206, memRooms and SUBMIT_WINDOW_SEC are
+      referenced before their later declarations (lines ~273–275); move the
+      declarations for memRooms and SUBMIT_WINDOW_SEC up to the top of the file
+      immediately after the DB initialization block so they are defined before any
+      use, and then remove the duplicate declarations at lines 273–275 to avoid
+      confusion and reliance on hoisting.
 
-- -- advance published rounds whose continue window closed
-- WITH due AS (
-- SELECT r.\* FROM rounds r
-- WHERE r.phase = 'published' AND r.continue_vote_close_unix IS NOT NULL AND r.continue_vote_close_unix < now_unix
-- ), tallied AS (
-- SELECT d.room_id, d.id as round_id,
--           COALESCE(SUM(CASE WHEN v.kind='continue' AND (v.ballot->>'choice')='continue' THEN 1 ELSE 0 END), 0) AS yes,
--           COALESCE(SUM(CASE WHEN v.kind='continue' AND (v.ballot->>'choice')='end' THEN 1 ELSE 0 END), 0) AS no
-- FROM due d
-- LEFT JOIN votes v ON v.round_id = d.id
-- GROUP BY d.room_id, d.id
-- ), winners AS (
-- SELECT t.\*, r.idx FROM tallied t JOIN rounds r ON r.id = t.round_id
-- )
-- UPDATE rounds r SET phase = 'final'
-- FROM winners w
-- WHERE r.id = w.round_id AND w.yes <= w.no;
--
-- -- create next round for winners
-- WITH due AS (
-- SELECT r.\* FROM rounds r
-- WHERE r.phase = 'published' AND r.continue_vote_close_unix IS NOT NULL AND r.continue_vote_close_unix < now_unix
-- ), tallied AS (
-- SELECT d.room_id, d.id as round_id,
--           COALESCE(SUM(CASE WHEN v.kind='continue' AND (v.ballot->>'choice')='continue' THEN 1 ELSE 0 END), 0) AS yes,
--           COALESCE(SUM(CASE WHEN v.kind='continue' AND (v.ballot->>'choice')='end' THEN 1 ELSE 0 END), 0) AS no
-- FROM due d
-- LEFT JOIN votes v ON v.round_id = d.id
-- GROUP BY d.room_id, d.id
-- ), winners AS (
-- SELECT t.\*, r.idx FROM tallied t JOIN rounds r ON r.id = t.round_id
-- )
-- INSERT INTO rounds (room_id, idx, phase, submit_deadline_unix)
-- SELECT w.room_id, w.idx + 1, 'submit', now_unix + 300::bigint
-- FROM winners w
-- WHERE w.yes > w.no
-- ON CONFLICT (room_id, idx) DO NOTHING;
-  WITH due AS (
+- [ ] In server/test/cli.room.create.test.js around lines 23–41, the in-promise
+      timeout (8000ms) does not match the Jest test timeout (15000ms), which is
+      confusing and can cause misleading failures; update the code so both timeouts
+      are the same (e.g., change the setTimeout duration from 8000 to 15000) or
+      introduce a shared TIMEOUT constant and use it for both the promise and the test
+      timeout, or if there is a deliberate reason for differing values, add a one-line
+      comment explaining why they differ.
 
-* SELECT r.\* FROM rounds r
-* WHERE r.phase = 'published'
-*      AND r.continue_vote_close_unix IS NOT NULL
-*      AND r.continue_vote_close_unix < now_unix
-* ), tallied AS MATERIALIZED (
-* SELECT d.room_id,
-*           d.id AS round_id,
-*           r.idx,
-*           COALESCE(SUM(CASE WHEN v.kind = 'continue' AND (v.ballot->>'choice') = 'continue' THEN 1 ELSE 0 END), 0) AS yes,
-*           COALESCE(SUM(CASE WHEN v.kind = 'continue' AND (v.ballot->>'choice') = 'end' THEN 1 ELSE 0 END), 0) AS no
-* FROM due d
-* JOIN rounds r ON r.id = d.id
-* LEFT JOIN votes v ON v.round_id = d.id
-* GROUP BY d.room_id, d.id, r.idx
-* ), losers AS (
-* UPDATE rounds r
-* SET phase = 'final'
-* FROM tallied t
-* WHERE r.id = t.round_id
-*      AND t.yes <= t.no
-* RETURNING 1
-* )
-* INSERT INTO rounds (room_id, idx, phase, submit_deadline_unix)
-* SELECT t.room_id,
-*         t.idx + 1,
-*         'submit',
-*         now_unix + 300::bigint
-* FROM tallied t
-* WHERE t.yes > t.no
-  ON CONFLICT (room_id, idx) DO NOTHING;
+- [ ] In server/test/cli.room.create.test.js around lines 28 to 37, the Promise
+      waiting for the child process only reads stdout, never collects stderr, and on
+      timeout it rejects without killing the child or checking the child's exit code;
+      update the logic to (1) accumulate both stdout and stderr into separate buffers,
+      (2) use a single timeout constant (match the test timeout, e.g. 15000ms) and on
+      timeout clear listeners, kill the child (child.kill()), and reject with a
+      timeout error that includes stderr, (3) on 'close' resolve with an object
+      containing stdout, stderr and the numeric exit code (or at least reject if
+      exitCode !== 0, including stderr), and (4) attach 'error' handling as before;
+      ensure the test then asserts on exit code zero and uses stderr in failure
+      messages so errors are visible.
 
-- [x] In db/rls.sql around lines 3 to 7, you enabled RLS for rooms, participants,
-      rounds, and votes but only created policies for submissions; as a result direct
-      SELECTs in tests will be denied. Add explicit RLS policies for those tables
-      (rooms, participants, rounds, votes) mirroring the submissions policy logic used
-      elsewhere — e.g. allow the service-role or authenticated users via auth
-      functions for SELECT/INSERT/UPDATE/DELETE as appropriate, or alternatively route
-      all access through security-definer RPCs/service-role functions or temporarily
-      disable RLS until policies exist; implement the chosen approach consistently so
-      the tests that perform direct selects (watcher.db.flip.test.js line ~42 and
-      rpc.db.postgres.test.js line ~114) have permission.
-
-- [x] In db/rls.sql around lines 19 to 29, the RLS policy uses a per-row subquery
-      (exists (select 1 from rounds r where r.id = submissions.round_id and r.phase =
-      'published')) which will cause severe performance issues on large tables; fix it
-      by ensuring there is a supporting index on rounds(id, phase) (create or confirm
-      index exists), or better by materializing the round phase on submissions (add a
-      submissions.round_phase column kept in sync) or by switching to a view that
-      joins submissions to rounds with proper indexing, and at minimum add a clear
-      comment above this policy stating the index requirement and advising the
-      materialization/view alternatives for performance.
-
-- [x] In docs/Backlog-2025-10-01.md around lines 12 to 25, task #1 is marked complete
-      (PR closes #73) but still contains a gh issue create command that would
-      duplicate the issue; either remove the entire task entry since the PR closed it,
-      or replace the gh issue create command with a reference to the existing issue
-      (e.g., change the command to comment/close/associate #73 or update the text to
-      "Issue #73 (ADR: SSE...) — closed by this PR") so the backlog accurately
-      reflects the issue state and avoids creating duplicates.
-
-- [x] In docs/GettingStarted.md around lines 35–40, the SSE endpoint GET
-      /events?room_id=<uuid> lacks detailed specs; update this section to enumerate
-      all SSE event types (timer, phase) and include exact JSON payload schemas
-      matching server/rpc.js (refer to lines ~342–343 and ~375–376), add examples of
-      full SSE frames for each event, document possible error frames and HTTP error
-      responses (404, 500) and their JSON bodies, and provide connection/reconnect
-      guidance (recommended EventSource retry behavior, timeouts, and
-      heartbeat/reconnect examples). Ensure each event lists fields, types, example
-      values, and a short note on client handling/idempotency for repeated frames.
-
-- [x] In docs/GettingStarted.md around lines 86 to 96, the watcher setup text is
-      duplicated elsewhere; remove the duplicated watcher instructions here and
-      replace them with a one-line reference pointing to the single authoritative
-      watcher section (ideally located after "Start the server"); update any other
-      location to link to that canonical section and ensure GettingStarted.md still
-      links to LocalDB.md for DB setup (line 27 already does), so consolidate content
-      by keeping only one full watcher walkthrough and converting other occurrences to
-      "see section X" links or transclusions.
-
-- [x] server/test/sse.db.events.test.js lines 60-119: the test timeout is set to
-      15000ms which is unnecessarily long; shorten it and make the test deterministic
-      by either lowering the jest/mocha timeout to 5000ms (or 3000ms) and/or
-      eliminating time-based waits by immediately setting DB timestamps so the NOTIFY
-      fires instantly (e.g. set published_at_unix and continue_vote_close_unix to now
-      and now+1 in the update), or use fake timers to advance time; update the final
-      timeout value and/or adjust the DB update values or test harness to ensure
-      completion within the shorter timeout.
-
-- [x] In server/test/sse.db.events.test.js around lines 71 to 93, the async onData
-      callback calls await pool.query(...) without error handling; wrap that await
-      call in a try-catch and on catch call the surrounding Promise's reject (or
-      otherwise fail the test) so the test fails fast instead of leaving an unhandled
-      rejection and hanging; ensure the catch passes the error to the test harness
-      (e.g., reject(err) or done(err) / stream.destroy(err)) and return after handling
-      to stop further processing.
-
-- [x] In server/test/watcher.db.flip.test.js around lines 16 to 22, the beforeAll
-      blindly executes db/schema.sql and db/rpc.sql which causes race conditions and
-      "already exists" errors when test suites run in parallel; change it to first
-      query the DB for an existing object (e.g. select to_regclass('public.rooms')
-      like in sse.db.events.test.js) and only execute schema.sql and rpc.sql when the
-      check returns null (or otherwise create/use a unique schema per suite), ensuring
-      you guard schema creation to avoid duplicate loads in concurrent runs.
-
-- [x] In server/test/watcher.db.flip.test.js around lines 27–47, the test inserts a
-      room and round but does not remove them afterwards which pollutes DB state and
-      can cause conflicts on re-runs; update the test file to either use per-test
-      unique IDs (e.g., generate UUIDs) or add proper teardown that deletes the
-      inserted rows (or wraps the test in a transaction and rolls back) — implement an
-      afterAll/afterEach that deletes the room and round by id (or rolls back the
-      transaction) so tests clean up their data and avoid constraint/flakiness issues.
-
-- [x] In server/test/watcher.transitions.test.js around lines 25 to 28, the test is
-      currently skipped and suffers from a race between submit and published windows;
-      re-enable the test by removing test.skip and make it deterministic by stubbing
-      Date.now (or using Jest fake timers) so timestamps used to drive phase
-      transitions are controlled. Specifically, replace test.skip with test, set up a
-      deterministic clock before the test (e.g., jest.useFakeTimers or mock Date.now)
-      to fix nowSec and advance timers/time values explicitly to simulate the submit
-      window elapsing and the published window starting, then perform the request and
-      assertions; restore timers/mocks after the test to avoid cross-test pollution.
+- [ ] In server/test/rpc.room_create.test.js around lines 15 to 18, the test claims
+      idempotency but only checks that the second response is a valid string instead
+      of asserting it matches the first response; update the code so the nonce-to-room
+      mapping is honored in all execution paths (including the in-memory fallback) by
+      storing/looking-up the nonce and returning the same room_id for duplicate
+      nonces, and change the test to assert
+      expect(r2.body.room_id).toBe(r1.body.room_id) (and keep the existing ok/type
+      checks).

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -12,6 +12,11 @@ cleanup() {
 
 trap cleanup EXIT
 
-# In non-interactive environments (like git hooks), the input device may not be a TTY.
-# Use -T to disable TTY allocation to avoid "the input device is not a TTY" errors.
-docker compose -f "$COMPOSE_FILE" run -T --rm tests bash -lc 'npm ci && npm run test:prepare-db && npm run test:inner'
+# Detect TTY: disable TTY only when stdin is not a TTY.
+# This keeps interactive runs attached while CI/hooks avoid the "not a TTY" error.
+DOCKER_TTY=""
+if [ ! -t 0 ]; then
+  DOCKER_TTY="-T"
+fi
+
+docker compose -f "$COMPOSE_FILE" run $DOCKER_TTY --rm tests bash -lc 'npm ci && npm run test:prepare-db && npm run test:inner'

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -12,4 +12,6 @@ cleanup() {
 
 trap cleanup EXIT
 
-docker compose -f "$COMPOSE_FILE" run --rm tests bash -lc 'npm ci && npm run test:prepare-db && npm run test:inner'
+# In non-interactive environments (like git hooks), the input device may not be a TTY.
+# Use -T to disable TTY allocation to avoid "the input device is not a TTY" errors.
+docker compose -f "$COMPOSE_FILE" run -T --rm tests bash -lc 'npm ci && npm run test:prepare-db && npm run test:inner'

--- a/server/rpc.js
+++ b/server/rpc.js
@@ -214,7 +214,7 @@ app.post('/rpc/room.create', async (req, res) => {
         ok: true,
         room_id: existing,
         note: 'db_fallback',
-        db_error: dbError?.message || String(dbError || '')
+        db_error: dbError?.message || undefined
       });
     }
     const room_id = crypto.randomUUID();

--- a/server/rpc.js
+++ b/server/rpc.js
@@ -202,12 +202,12 @@ app.post('/rpc/room.create', async (req, res) => {
         return res.json({ ok: true, room_id });
       } catch (e) {
         dbError = e;
-        console.error('room.create DB error; using in-memory fallback', e);
+        console.warn('room.create DB error; using in-memory fallback', e);
         // fall through to memory path only if DB call fails
       }
     }
     // in-memory: generate a room id and initialize round 0
-    const nonce = String(input.client_nonce || '');
+    const nonce = input.client_nonce ?? '';
     if (nonce && memRoomNonces.has(nonce)) {
       const existing = memRoomNonces.get(nonce);
       return res.json({

--- a/server/schemas.js
+++ b/server/schemas.js
@@ -39,6 +39,17 @@ export const ContinueVote = z.object({
   client_nonce: z.string().min(8)
 });
 
+export const RoomCreate = z.object({
+  topic: z.string().min(3),
+  cfg: z
+    .object({
+      participant_count: z.number().int().min(1).max(64).optional(),
+      submit_minutes: z.number().int().min(1).max(1440).optional()
+    })
+    .optional(),
+  client_nonce: z.string().min(8).optional()
+});
+
 export const SubmissionFlag = z.object({
   submission_id: z.string().uuid(),
   reporter_id: z.string().min(1),

--- a/server/test/cli.room.create.test.js
+++ b/server/test/cli.room.create.test.js
@@ -32,8 +32,9 @@ describe('CLI room create', () => {
       const to = setTimeout(() => {
         try {
           child.kill();
-        } catch {
-          // ignore kill errors
+        } catch (killErr) {
+          // surface kill errors for visibility but do not fail the test immediately
+          console.warn('cli.room.create: failed to kill child on timeout', killErr);
         }
         reject(new Error(`timeout. stderr=${err}`));
       }, TIMEOUT);

--- a/server/test/cli.room.create.test.js
+++ b/server/test/cli.room.create.test.js
@@ -1,0 +1,42 @@
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import app from '../rpc.js';
+
+function cliBin() {
+  return path.join(process.cwd(), 'bin', 'db8.js');
+}
+
+describe('CLI room create', () => {
+  let server;
+  let url;
+  beforeAll(async () => {
+    server = http.createServer(app);
+    await new Promise((r) => server.listen(0, r));
+    const port = server.address().port;
+    url = `http://127.0.0.1:${port}`;
+  });
+  afterAll(async () => {
+    await new Promise((r) => server.close(r));
+  });
+
+  test('creates a room and prints room_id (JSON)', async () => {
+    const env = { ...process.env, DB8_API_URL: url };
+    const child = spawn('node', [cliBin(), 'room', 'create', '--topic', 'CLI Demo', '--json'], {
+      env
+    });
+    const out = await new Promise((resolve, reject) => {
+      let buf = '';
+      const to = setTimeout(() => reject(new Error('timeout')), 8000);
+      child.stdout.on('data', (d) => (buf += d.toString()));
+      child.on('close', () => {
+        clearTimeout(to);
+        resolve(buf.trim());
+      });
+      child.on('error', reject);
+    });
+    const j = JSON.parse(out);
+    expect(j.ok).toBe(true);
+    expect(typeof j.room_id).toBe('string');
+  }, 15000);
+});

--- a/server/test/rpc.room_create.test.js
+++ b/server/test/rpc.room_create.test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import app from '../rpc.js';
+
+describe('POST /rpc/room.create', () => {
+  it('creates a room and returns room_id; idempotent by client_nonce', async () => {
+    const body = {
+      topic: 'Demo Topic',
+      cfg: { participant_count: 4, submit_minutes: 2 },
+      client_nonce: 'room-nonce-1234'
+    };
+    const r1 = await request(app).post('/rpc/room.create').send(body).expect(200);
+    const r2 = await request(app).post('/rpc/room.create').send(body).expect(200);
+    expect(r1.body.ok).toBe(true);
+    expect(typeof r1.body.room_id).toBe('string');
+    // In DB path, same nonce returns same room; in memory fallback we accept any UUID and same nonce may still regenerate
+    // To keep this test robust across both paths, assert both responses are ok and return valid uuid-looking strings.
+    expect(r2.body.ok).toBe(true);
+    expect(typeof r2.body.room_id).toBe('string');
+  });
+
+  it('rejects invalid topic', async () => {
+    const res = await request(app).post('/rpc/room.create').send({ topic: 'a' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/test/rpc.room_create.test.js
+++ b/server/test/rpc.room_create.test.js
@@ -12,10 +12,8 @@ describe('POST /rpc/room.create', () => {
     const r2 = await request(app).post('/rpc/room.create').send(body).expect(200);
     expect(r1.body.ok).toBe(true);
     expect(typeof r1.body.room_id).toBe('string');
-    // In DB path, same nonce returns same room; in memory fallback we accept any UUID and same nonce may still regenerate
-    // To keep this test robust across both paths, assert both responses are ok and return valid uuid-looking strings.
     expect(r2.body.ok).toBe(true);
-    expect(typeof r2.body.room_id).toBe('string');
+    expect(r2.body.room_id).toBe(r1.body.room_id);
   });
 
   it('rejects invalid topic', async () => {


### PR DESCRIPTION
Summary
- Add end-to-end room creation to complete M1 story for setting up a room without manual SQL.

Changes
- server: POST /rpc/room.create (calls SQL room_create with topic/cfg/nonce; memory fallback)
- schemas: add RoomCreate Zod schema
- CLI: `db8 room create --topic <str> [--participants N] [--submit-minutes M] [--nonce id] [--json]`
- tests: server + CLI coverage; idempotency by nonce for DB path; robust for memory fallback

Notes
- No auto-merge; awaiting review/feedback.
- Docs touch-up to follow after API/CLI review (short snippets for GettingStarted + CLI docs).

