### PR TITLE
feat(db): RLS + secure views (security_barrier) and tests (Fixes #65)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,9 @@ Operational notes (for future‑you)
 - Merge methods
   - Repo allows Merge and Rebase; Squash is disabled. Use Merge in gh/PR UI
     unless Rulesets require linear history (then use Rebase).
-  - Auto‑merge: enable per‑PR (UI or `gh pr merge <n> --merge --auto`) after
-    required checks/approvals are green.
+  - Do not enable auto‑merge. Wait for CodeRabbit (or designated reviewer)
+    feedback before merging. Merge manually via the GitHub UI once required
+    checks and reviews are complete.
   - Rulesets vs legacy protection: REST `branches/*/protection` 404 is normal if
     using Rulesets. Ensure required checks match names exactly (`build-test`,
     `conventional-commits`).

--- a/db/rpc.sql
+++ b/db/rpc.sql
@@ -220,6 +220,11 @@ CREATE OR REPLACE VIEW submissions_with_flags_view AS
      GROUP BY submission_id
   ) f ON f.submission_id = s.id;
 
+-- Harden views to avoid qual pushdown across RLS boundaries
+ALTER VIEW submissions_view SET (security_barrier = true);
+ALTER VIEW votes_view SET (security_barrier = true);
+ALTER VIEW submissions_with_flags_view SET (security_barrier = true);
+
 -- Notify function
 CREATE OR REPLACE FUNCTION notify_rounds_change() RETURNS trigger AS $fn$
 DECLARE

--- a/db/test/42_view_rls_submit_publish.pgtap
+++ b/db/test/42_view_rls_submit_publish.pgtap
@@ -1,6 +1,6 @@
 -- 42_view_rls_submit_publish.pgtap — RLS behavior through secure views
 BEGIN;
-SELECT plan(4);
+SELECT plan(3);
 
 -- Seed data for a new room/round with two participants
 DO $$
@@ -50,4 +50,3 @@ SELECT results_eq(
 
 SELECT finish();
 ROLLBACK;
-

--- a/db/test/42_view_rls_submit_publish.pgtap
+++ b/db/test/42_view_rls_submit_publish.pgtap
@@ -1,0 +1,53 @@
+-- 42_view_rls_submit_publish.pgtap — RLS behavior through secure views
+BEGIN;
+SELECT plan(4);
+
+-- Seed data for a new room/round with two participants
+DO $$
+DECLARE rid uuid := '30000000-0000-0000-0000-000000000001';
+        r0  uuid := '30000000-0000-0000-0000-000000000002';
+        p1  uuid := '30000000-0000-0000-0000-000000000003';
+        p2  uuid := '30000000-0000-0000-0000-000000000004';
+BEGIN
+  INSERT INTO rooms(id,title) VALUES (rid,'View RLS Room') ON CONFLICT DO NOTHING;
+  INSERT INTO rounds(id,room_id,idx,phase,submit_deadline_unix)
+    VALUES (r0,rid,0,'submit', extract(epoch from now())::bigint + 300)
+    ON CONFLICT DO NOTHING;
+  INSERT INTO participants(id,room_id,anon_name,role)
+    VALUES (p1,rid,'anon_1','debater'),(p2,rid,'anon_2','debater')
+    ON CONFLICT DO NOTHING;
+  INSERT INTO submissions(round_id, author_id, content, canonical_sha256, client_nonce)
+    VALUES (r0,p1,'A','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','n1')
+    ON CONFLICT DO NOTHING;
+  INSERT INTO submissions(round_id, author_id, content, canonical_sha256, client_nonce)
+    VALUES (r0,p2,'B','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','n2')
+    ON CONFLICT DO NOTHING;
+END $$;
+
+-- During submit: each author sees only their row via submissions_with_flags_view
+SELECT set_config('db8.participant_id','30000000-0000-0000-0000-000000000003', false);
+SELECT results_eq(
+  $$ SELECT count(*)::int FROM submissions_with_flags_view v JOIN rounds r ON r.id=v.round_id WHERE r.phase='submit' $$,
+  ARRAY[1::int],
+  'During submit: author p1 sees only 1 row via view'
+);
+
+SELECT set_config('db8.participant_id','30000000-0000-0000-0000-000000000004', false);
+SELECT results_eq(
+  $$ SELECT count(*)::int FROM submissions_with_flags_view v JOIN rounds r ON r.id=v.round_id WHERE r.phase='submit' $$,
+  ARRAY[1::int],
+  'During submit: author p2 sees only 1 row via view'
+);
+
+-- After publish: anyone sees both
+UPDATE rounds SET phase='published', published_at_unix = extract(epoch from now())::bigint WHERE id='30000000-0000-0000-0000-000000000002';
+SELECT set_config('db8.participant_id','00000000-0000-0000-0000-000000000000', false);
+SELECT results_eq(
+  $$ SELECT count(*)::int FROM submissions_with_flags_view v JOIN rounds r ON r.id=v.round_id WHERE r.phase='published' $$,
+  ARRAY[2::int],
+  'After publish: both rows visible via view'
+);
+
+SELECT finish();
+ROLLBACK;
+

--- a/docs/LocalDB.md
+++ b/docs/LocalDB.md
@@ -26,7 +26,23 @@ Load the M1 schema and SQL RPCs into your database:
 ```text
 psql postgresql://postgres:test@localhost:54329/db8 -f db/schema.sql
 psql postgresql://postgres:test@localhost:54329/db8 -f db/rpc.sql
+```
+
+### RLS and Secure Views
+
+Row-Level Security (RLS) is enabled for core tables, and the server reads via
+secure views only. Views are marked as `security_barrier` to prevent predicate
+pushdown across RLS boundaries.
+
+- Files
+  - `db/rls.sql`: enables RLS and defines policies.
+  - `db/rpc.sql`: defines read-only views and sets `security_barrier=true`.
+
+The prep script applies schema, RPCs, and RLS:
+
 ```text
+npm run test:prepare-db
+```
 
 ### Create a Room + Seed Participants
 

--- a/docs/LocalDB.md
+++ b/docs/LocalDB.md
@@ -32,7 +32,7 @@ psql postgresql://postgres:test@localhost:54329/db8 -f db/rpc.sql
 
 Row-Level Security (RLS) is enabled for core tables, and the server reads via
 secure views only. Views are marked as `security_barrier` to prevent predicate
-pushdown across RLS boundaries.
+push-down across RLS boundaries.
 
 - Files
   - `db/rls.sql`: enables RLS and defines policies.

--- a/scripts/prepare-db.js
+++ b/scripts/prepare-db.js
@@ -26,12 +26,14 @@ async function main() {
   const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const schemaPath = path.join(rootDir, 'db', 'schema.sql');
   const rpcPath = path.join(rootDir, 'db', 'rpc.sql');
+  const rlsPath = path.join(rootDir, 'db', 'rls.sql');
 
   const client = new Client({ connectionString: dbUrl });
   await client.connect();
   try {
     if (await fileExists(schemaPath)) await applyFile(client, schemaPath);
     if (await fileExists(rpcPath)) await applyFile(client, rpcPath);
+    if (await fileExists(rlsPath)) await applyFile(client, rlsPath);
   } finally {
     await client.end();
   }


### PR DESCRIPTION
## Summary
Harden DB read path under RLS with secure (security_barrier) views; apply RLS during DB prep; add pgTAP test to prove RLS behavior via views; document policy.

## Changes
- db/rpc.sql: ALTER VIEW ... SET (security_barrier=true) for submissions_view, votes_view, submissions_with_flags_view
- scripts/prepare-db.js: also apply db/rls.sql
- db/test/42_view_rls_submit_publish.pgtap: assert RLS behavior through view during submit and after publish
- docs/LocalDB.md: RLS + secure views section; prep script note

## Tests
- Vitest suite: green (Docker-backed).
- pgTAP: can be run locally via `db/test/run.sh`.

## Notes
- This PR should close #65.
