### PR TITLE
feat(db,ci,docs,tests): switch to db8_test; add audit RPC; harden helpers/RLS; fix vote_submit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,11 +35,11 @@ jobs:
         image: postgres:16-alpine
         env:
           POSTGRES_PASSWORD: test
-          POSTGRES_DB: db8
+          POSTGRES_DB: db8_test
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U postgres -d db8"
+          --health-cmd="pg_isready -U postgres -d db8_test"
           --health-interval=10s --health-timeout=5s --health-retries=10
 
     steps:
@@ -56,13 +56,13 @@ jobs:
 
       - name: Prepare DB schema/RPC
         env:
-          DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
+          DATABASE_URL: postgresql://postgres:test@localhost:5432/db8_test
           DB8_TEST_OUTPUT: quiet
         run: npm run test:prepare-db
 
       - name: Run tests (vitest)
         env:
-          DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
-          DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/db8
+          DATABASE_URL: postgresql://postgres:test@localhost:5432/db8_test
+          DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/db8_test
           CI: true
         run: npm run test:inner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         image: postgres:16
         env:
           POSTGRES_PASSWORD: test
-          POSTGRES_DB: db8
+          POSTGRES_DB: db8_test
         ports: ["54329:5432"]
         options: >-
           --health-cmd="pg_isready -U postgres" --health-interval=10s
@@ -47,27 +47,27 @@ jobs:
 
       - name: DB setup
         env:
-          PGURL: postgresql://postgres:test@localhost:54329/db8
+          PGURL: postgresql://postgres:test@localhost:54329/db8_test
         run: |
           if [ -f db/schema.sql ]; then psql "$PGURL" -f db/schema.sql; fi
           if [ -f db/rpc.sql ]; then psql "$PGURL" -f db/rpc.sql || true; fi
 
       - name: Tests
         env:
-          DATABASE_URL: postgresql://postgres:test@localhost:54329/db8
+          DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
         run: npm test
 
       - name: Tests (Postgres RPC integration)
         env:
           RUN_PGTAP: '1'
-          DATABASE_URL: postgresql://postgres:test@localhost:54329/db8
-          DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:54329/db8
+          DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
+          DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
         run: npx vitest run server/test/rpc.db.postgres.test.js
 
       - name: pgTAP (optional)
         if: ${{ vars.RUN_PGTAP == '1' || github.event.inputs.run_pgtap == '1' }}
         env:
-          PGURL: postgresql://postgres:test@localhost:54329/db8
+          PGURL: postgresql://postgres:test@localhost:54329/db8_test
         run: |
           if [ -f "db/test/run.sh" ]; then
             chmod +x db/test/run.sh

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -94,7 +94,7 @@ CREATE INDEX IF NOT EXISTS idx_submission_flags_submission ON submission_flags (
 DROP TABLE IF EXISTS admin_audit_log CASCADE;
 
 CREATE TABLE admin_audit_log (
-  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  id            uuid NOT NULL DEFAULT gen_random_uuid(),
   action        text        NOT NULL,
   entity_type   text        NOT NULL,
   entity_id     uuid        NOT NULL,
@@ -115,7 +115,8 @@ CREATE TABLE admin_audit_log (
   -- Exactly one of actor_id or system_actor must be set
   CONSTRAINT admin_audit_actor_oneof_ck
     CHECK ((actor_id IS NOT NULL AND system_actor IS NULL)
-        OR (actor_id IS NULL AND system_actor IS NOT NULL))
+        OR (actor_id IS NULL AND system_actor IS NOT NULL)),
+  PRIMARY KEY (created_at, id)
 )
 PARTITION BY RANGE (created_at);
 
@@ -127,6 +128,7 @@ CREATE TABLE IF NOT EXISTS admin_audit_log_default PARTITION OF admin_audit_log
 CREATE INDEX IF NOT EXISTS idx_admin_audit_entity ON admin_audit_log (entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_admin_audit_created_at_desc ON admin_audit_log (created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_admin_audit_actor_time ON admin_audit_log (actor_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_id ON admin_audit_log (id);
 
 COMMENT ON TABLE admin_audit_log IS 'Administrative audit log; RLS locked down. Writes via privileged service only.';
 COMMENT ON COLUMN admin_audit_log.actor_context IS 'Additional context about actor (e.g., IP, UA), JSON';

--- a/db/test/helpers.sql
+++ b/db/test/helpers.sql
@@ -7,16 +7,67 @@ CREATE OR REPLACE FUNCTION round_set_submit_deadline(
   p_submit_deadline_unix bigint
 ) RETURNS void
 LANGUAGE plpgsql
-SECURITY DEFINER
 AS $$
 BEGIN
-  IF COALESCE(current_setting('app.env', true), '') <> 'test' THEN
-    RAISE EXCEPTION 'TEST ONLY: round_set_submit_deadline not available in production'
+  -- Strict DB-name guard: only allow in databases clearly marked as test.
+  -- Accepted patterns: '<prefix>_test' or 'test_<suffix>'.
+  IF NOT (
+    current_database() LIKE '%\_test' ESCAPE '\' OR
+    current_database() LIKE 'test\_%' ESCAPE '\'
+  ) THEN
+    RAISE EXCEPTION 'TEST ONLY: round_set_submit_deadline is not available in non-test databases (db=%)', current_database()
       USING ERRCODE = '42501';
+  END IF;
+
+  -- Validate inputs
+  IF p_round_id IS NULL THEN
+    RAISE EXCEPTION 'p_round_id is required' USING ERRCODE = '22023';
+  END IF;
+  IF p_submit_deadline_unix IS NULL OR p_submit_deadline_unix < 0 OR p_submit_deadline_unix > 4102444800 THEN
+    RAISE EXCEPTION 'invalid submit_deadline_unix: % (expected 0..4102444800)', p_submit_deadline_unix USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1 FROM rounds WHERE id = p_round_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'round not found: %', p_round_id USING ERRCODE = '22023';
   END IF;
 
   UPDATE rounds
      SET submit_deadline_unix = p_submit_deadline_unix
    WHERE id = p_round_id;
+END;
+$$;
+
+-- TEST ONLY: delete a round by id (teardown helper)
+CREATE OR REPLACE FUNCTION round_delete(p_round_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT (
+    current_database() LIKE '%\_test' ESCAPE '\' OR
+    current_database() LIKE 'test\_%' ESCAPE '\'
+  ) THEN
+    RAISE EXCEPTION 'TEST ONLY: round_delete is not available in non-test databases (db=%)', current_database()
+      USING ERRCODE = '42501';
+  END IF;
+  DELETE FROM rounds WHERE id = p_round_id;
+END;
+$$;
+
+-- TEST ONLY: delete a room by id (teardown helper)
+CREATE OR REPLACE FUNCTION room_delete(p_room_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT (
+    current_database() LIKE '%\_test' ESCAPE '\' OR
+    current_database() LIKE 'test\_%' ESCAPE '\'
+  ) THEN
+    RAISE EXCEPTION 'TEST ONLY: room_delete is not available in non-test databases (db=%)', current_database()
+      USING ERRCODE = '42501';
+  END IF;
+  DELETE FROM rooms WHERE id = p_room_id;
 END;
 $$;

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:16
     environment:
       POSTGRES_PASSWORD: test
-      POSTGRES_DB: db8
+      POSTGRES_DB: db8_test
     ports: ["54329:5432"]
 
   tests:
@@ -14,8 +14,8 @@ services:
         condition: service_started
     environment:
       NODE_ENV: test
-      DATABASE_URL: postgresql://postgres:test@db:5432/db8
-      DB8_TEST_DATABASE_URL: postgresql://postgres:test@db:5432/db8
+      DATABASE_URL: postgresql://postgres:test@db:5432/db8_test
+      DB8_TEST_DATABASE_URL: postgresql://postgres:test@db:5432/db8_test
     volumes:
       - ./:/app
       - node_modules_linux:/app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,10 @@ services:
     image: postgres:16
     environment:
       POSTGRES_PASSWORD: test
-      POSTGRES_DB: db8
+      POSTGRES_DB: db8_test
     ports: ["54329:5432"]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d db8"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d db8_test"]
       interval: 5s
       timeout: 3s
       retries: 10
-

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -26,12 +26,17 @@ npm install
 npm run dev:db      # starts Postgres 16 on localhost:54329
 ```text
 
-Set `DATABASE_URL=postgresql://postgres:test@localhost:54329/db8` in your shell
+Set `DATABASE_URL=postgresql://postgres:test@localhost:54329/db8_test`
+in your shell
 if you want the server to persist submissions/votes. Without it, the server uses
 in‑memory storage with idempotency.
 
 To apply the M1 schema and SQL RPCs to your local DB and optionally run pgTAP
 invariants, see docs/LocalDB.md.
+
+Note: test-only SQL helpers live in `db/test/helpers.sql` and refuse to run
+unless the database name is clearly a test database (e.g., `db8_test`). Do not
+load them in production.
 
 ## Start the server
 
@@ -94,7 +99,8 @@ first and pass the Postgres environment variables:
 
 ```text
 npm run dev:db
-RUN_PGTAP=1 DB8_TEST_DATABASE_URL=postgresql://postgres:test@localhost:54329/db8
+RUN_PGTAP=1 \
+DB8_TEST_DATABASE_URL=postgresql://postgres:test@localhost:54329/db8_test
 npm test
 ```text
 
@@ -141,7 +147,7 @@ The watcher flips rounds at deadlines using SQL RPCs and relies on DB triggers
 to fan out changes via SSE.
 
 ```text
-export DATABASE_URL=postgresql://postgres:test@localhost:54329/db8
+export DATABASE_URL=postgresql://postgres:test@localhost:54329/db8_test
 node server/watcher.js
 ```text
 

--- a/scripts/prepare-db.js
+++ b/scripts/prepare-db.js
@@ -22,7 +22,7 @@ async function applyFile(client, filePath) {
 }
 
 async function main() {
-  const dbUrl = process.env.DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8';
+  const dbUrl = process.env.DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8_test';
   const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const schemaPath = path.join(rootDir, 'db', 'schema.sql');
   const rpcPath = path.join(rootDir, 'db', 'rpc.sql');

--- a/server/test/setup.env.js
+++ b/server/test/setup.env.js
@@ -1,3 +1,3 @@
 process.env.NODE_ENV = 'test';
-process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8';
-
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8_test';

--- a/server/test/sse.db.events.test.js
+++ b/server/test/sse.db.events.test.js
@@ -9,7 +9,8 @@ const shouldRun =
   process.env.RUN_PGTAP === '1' ||
   process.env.DB8_TEST_PG === '1' ||
   process.env.DB8_TEST_DATABASE_URL;
-const dbUrl = process.env.DB8_TEST_DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8';
+const dbUrl =
+  process.env.DB8_TEST_DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8_test';
 
 const suite = shouldRun ? describe : describe.skip;
 


### PR DESCRIPTION
Summary

Hardens DB safety and test ergonomics, fixes vote idempotency, and standardizes test DB naming.

Changes

- db: rename compose/CI/test URLs to `db8_test` for clear test isolation
- rpc.sql: add `admin_audit_log_write(...)` (SECURITY DEFINER) for RLS-locked audit table
- schema.sql: recreate `admin_audit_log` with constraints, partitioning by `created_at`, and indexes
- rls.sql: enable RLS on audit log; add test-only update/delete policies for rounds/rooms
- test helpers: invoker-safe guard via `current_database()`; validate inputs; add `round_delete`/`room_delete`
- vote_submit: use `EXCLUDED.ballot`, validate phase/window/participation
- docs: update GettingStarted/LocalDB with `db8_test` and helper safety
- tests/CI: update URLs; swap teardown to RPC helpers

Tests

- Pre-push hooks ran dockerized test suite: all passing locally
- Verified watcher flip and SSE tests with db-backed path

Next

- (Optional) Wire `admin_audit_log_write(...)` into server flows (vote/submission/watcher) and add coverage
