### PR TITLE
feat(cli): add journal pull command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+---
+lastUpdated: 2025-10-04
+---
+
+# Changelog
+
+## 2025-10-04 — PR #118 merged (M2 foundations)
+
+- Canonicalization
+  - Added RFC 8785 JCS behind `CANON_MODE=jcs`; default remains `sorted` for compatibility.
+- Nonces (server-issued)
+  - Atomic DB path via `submission_upsert_with_nonce(...)` to consume-and-insert in one step.
+  - Clear fallbacks: `invalid_nonce` → 400; otherwise log DB error and fall back to memory (when enabled) with TTL + single-use semantics.
+  - Issuance (`/rpc/nonce.issue`) only falls back for infra errors; validation/constraints surfaced as 400.
+  - Memory guardrails: UUID v4 format, TTL, per-(round,author) windowed limit, global lazy sweep.
+- Journals
+  - Endpoints: `GET /journal`, `GET /journal?idx`, `GET /journal/history`.
+  - Web: `/journal/[roomId]` history page with client-side Ed25519 verify and clear ‘unsupported’ status.
+- Docs
+  - Documented `CANON_MODE`, `ENFORCE_SERVER_NONCES`, signing keys, and journal endpoints + CLI verify.
+- Tests
+  - TTL expiry for nonces; canonicalizer selection in tests respects `CANON_MODE`.
+- Misc
+  - Journal building avoids mutating DB rows; single numeric coercion prevents NaNs.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,10 +98,11 @@ Voting
 
 Journal & Verify
 
-- db8 journal pull [--round <idx>]
-  - Downloads signed journal artifacts for room/round
+- db8 journal pull [--room <uuid>] [--round <idx>] [--history] [--out <dir>]
+  - Downloads signed journal JSON for the latest round, a specific round (`--round`), or the full history (`--history`).
+  - Default output directory: `~/.db8/journal/<room>/`. Use `--out` to override.
 - db8 journal verify [--round <idx>]
-  - Verifies round.chain.sig and per-submission signatures
+  - Verifies the latest or a specific round’s signature and checks chain linkage when verifying history.
 
 Agent QoL (batch)
 
@@ -117,7 +118,7 @@ RPC Mapping
 - withdraw: POST /rpc/submission.withdraw
 - vote continue: POST /rpc/vote.continue
 - vote final: POST /rpc/vote.final
-- journal pull: GET /journal?room_id[&round]
+- journal pull: GET /journal?room_id[&idx] or GET /journal/history?room_id
 - journal verify: local
 
 Headers & Provenance
@@ -139,6 +140,7 @@ Sample Flows
   vote continue
 - Agent with SSH: login → draft → submit --sign → watch --json
 - Journal verify: pull → verify (print OK summary)
+  - `db8 journal pull --room <uuid> --history && db8 journal verify --room <uuid>`
 
 Zod Contracts (client mirror)
 

--- a/server/schemas.js
+++ b/server/schemas.js
@@ -59,3 +59,20 @@ export const SubmissionFlag = z.object({
     .default('participant'),
   reason: z.string().max(500).optional().default('')
 });
+
+export const SubmissionVerify = z.object({
+  doc: z.object({
+    room_id: z.string().uuid(),
+    round_id: z.string().uuid(),
+    author_id: z.string().uuid(),
+    phase: z.enum(['submit', 'published', 'final']),
+    deadline_unix: z.number().int(),
+    content: z.string().min(1),
+    claims: z.array(Claim).min(1),
+    citations: z.array(Citation).min(2),
+    client_nonce: z.string().min(8)
+  }),
+  signature_kind: z.enum(['ed25519', 'ssh']),
+  sig_b64: z.string().min(1),
+  public_key_b64: z.string().optional()
+});

--- a/server/test/cli.journal.pull.test.js
+++ b/server/test/cli.journal.pull.test.js
@@ -1,0 +1,64 @@
+import http from 'node:http';
+import { execFile as _execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import app, { __setDbPool } from '../rpc.js';
+
+const execFile = promisify(_execFile);
+
+function cliBin() {
+  return path.join(process.cwd(), 'bin', 'db8.js');
+}
+
+describe('CLI journal pull', () => {
+  let server;
+  let url;
+  const room = '00000000-0000-0000-0000-00000000a001';
+
+  beforeAll(async () => {
+    __setDbPool(null);
+    server = http.createServer(app);
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+    url = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  test('pulls journal history to output directory', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'db8-journal-'));
+    const env = { ...process.env, DB8_API_URL: url };
+    const { stdout } = await execFile(
+      'node',
+      [cliBin(), 'journal', 'pull', '--room', room, '--history', '--out', tmp],
+      { env }
+    );
+
+    // Expect at least one round file (round-0.json) to be written
+    const out = stdout.trim().split(/\r?\n/).filter(Boolean);
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    const file = out[0];
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    expect(typeof data.hash).toBe('string');
+    const idx = data.round_idx ?? (data.core && data.core.idx);
+    expect(typeof idx).toBe('number');
+    expect(data.signature && typeof data.signature.sig_b64).toBe('string');
+  });
+
+  test('pulls latest single journal when no --history', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'db8-journal-'));
+    const env = { ...process.env, DB8_API_URL: url };
+    const { stdout } = await execFile(
+      'node',
+      [cliBin(), 'journal', 'pull', '--room', room, '--out', tmp],
+      { env }
+    );
+    const fp = stdout.trim();
+    const j = JSON.parse(await fs.readFile(fp, 'utf8'));
+    expect(j && typeof j.hash).toBe('string');
+  });
+});

--- a/server/test/provenance.verify.test.js
+++ b/server/test/provenance.verify.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
+
+// Force in-memory server
+process.env.DATABASE_URL = '';
+const app = (await import('../rpc.js')).default;
+
+describe('POST /rpc/provenance.verify', () => {
+  it('verifies an Ed25519 signature over the canonicalized submission', async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const public_key_b64 = Buffer.from(pubDer).toString('base64');
+
+    const doc = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      author_id: '00000000-0000-0000-0000-000000000003',
+      phase: 'submit',
+      deadline_unix: 0,
+      content: 'Hello provenance',
+      claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
+      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      client_nonce: 'nonce-12345678'
+    };
+
+    // Ask server to canonicalize internally, but we need the hash to sign
+    const server = http.createServer(app);
+    await new Promise((r) => server.listen(0, r));
+    const url = `http://127.0.0.1:${server.address().port}`;
+    const canonicalizer =
+      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+        ? canonicalizeJCS
+        : canonicalizeSorted;
+    const hashHex = sha256Hex(canonicalizer(doc));
+    const sig_b64 = Buffer.from(
+      crypto.sign(null, Buffer.from(hashHex, 'hex'), privateKey)
+    ).toString('base64');
+
+    const res = await fetch(url + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc, signature_kind: 'ed25519', sig_b64, public_key_b64 })
+    });
+    const body = await res.json().catch(() => ({}));
+    expect(res.status).toBe(200);
+    expect(body?.ok).toBe(true);
+    expect(typeof body?.hash).toBe('string');
+    await new Promise((r) => server.close(r));
+  });
+
+  it('returns 501 for SSH signatures (stub)', async () => {
+    const server = http.createServer(app);
+    await new Promise((r) => server.listen(0, r));
+    const url = `http://127.0.0.1:${server.address().port}`;
+    const doc = {
+      room_id: '00000000-0000-0000-0000-000000000001',
+      round_id: '00000000-0000-0000-0000-000000000002',
+      author_id: '00000000-0000-0000-0000-000000000003',
+      phase: 'submit',
+      deadline_unix: 0,
+      content: 'Hello',
+      claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
+      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      client_nonce: 'nonce-12345678'
+    };
+    const res = await fetch(url + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc, signature_kind: 'ssh', sig_b64: 'x' })
+    });
+    expect(res.status).toBe(501);
+    await new Promise((r) => server.close(r));
+  });
+});

--- a/server/test/rpc.submission_create.test.js
+++ b/server/test/rpc.submission_create.test.js
@@ -1,6 +1,9 @@
+/* eslint-disable import/first */
 import { describe, it, expect } from 'vitest';
 import request from 'supertest';
-import app from '../rpc.js';
+// Force in-memory path for this test to avoid DB coupling
+process.env.DATABASE_URL = '';
+const app = (await import('../rpc.js')).default;
 import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
 
 describe('POST /rpc/submission.create', () => {


### PR DESCRIPTION
Summary
- Adds db8 journal pull [--room] [--round] [--history] [--out].
- Normalizes idx across DB/memory; supports --json. Includes a focused test.

Changes
- bin/db8.js: help text, validation, implementation
- server/test/cli.journal.pull.test.js: tests latest/history paths
- docs/CLI.md: maps endpoints, options, examples

Tests
- New test verifies files written and signature/hash presence.

Next
- Optional: add a --verify flag to pull+verify in one go.

Fixes #123