### PR TITLE
fix(provenance): harden /rpc/provenance.verify + tests

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,6 +28,11 @@ npm run dev:db      # starts Postgres 16 on localhost:54329
 
 Set `DATABASE_URL=postgresql://postgres:test@localhost:54329/db8_test`
 in your shell
+
+## CLI reference
+
+- CLI reference/spec: see docs/CLI.md
+
 if you want the server to persist submissions/votes. Without it, the server uses
 in‑memory storage with idempotency.
 
@@ -186,3 +191,9 @@ when deadlines are crossed.
 - Read the architecture: docs/Architecture.md
 - Explore features & user stories: docs/Features.md, docs/UserStories.md
 - CLI reference/spec: docs/CLI.md
+
+### Submitting from the Web UI (nonces)
+
+When `ENFORCE_SERVER_NONCES=1` is set, the server requires a short‑lived, single‑use nonce for each submission. The Room page automatically requests a nonce via `POST /rpc/nonce.issue` before submitting. If issuance fails and enforcement is enabled, the UI will show “Submit failed: server requires an issued nonce.”
+
+You can disable enforcement during local demos by unsetting `ENFORCE_SERVER_NONCES`.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,11 +28,6 @@ npm run dev:db      # starts Postgres 16 on localhost:54329
 
 Set `DATABASE_URL=postgresql://postgres:test@localhost:54329/db8_test`
 in your shell
-
-## CLI reference
-
-- CLI reference/spec: see docs/CLI.md
-
 if you want the server to persist submissions/votes. Without it, the server uses
 in‑memory storage with idempotency.
 
@@ -191,9 +186,3 @@ when deadlines are crossed.
 - Read the architecture: docs/Architecture.md
 - Explore features & user stories: docs/Features.md, docs/UserStories.md
 - CLI reference/spec: docs/CLI.md
-
-### Submitting from the Web UI (nonces)
-
-When `ENFORCE_SERVER_NONCES=1` is set, the server requires a short‑lived, single‑use nonce for each submission. The Room page automatically requests a nonce via `POST /rpc/nonce.issue` before submitting. If issuance fails and enforcement is enabled, the UI will show “Submit failed: server requires an issued nonce.”
-
-You can disable enforcement during local demos by unsetting `ENFORCE_SERVER_NONCES`.

--- a/server/test/provenance.verify.test.js
+++ b/server/test/provenance.verify.test.js
@@ -1,12 +1,41 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import http from 'node:http';
 import crypto from 'node:crypto';
 import { Buffer } from 'node:buffer';
 import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
 
-// Force in-memory server
+// Force in-memory server for these tests
+const originalDbUrl = process.env.DATABASE_URL;
 process.env.DATABASE_URL = '';
 const app = (await import('../rpc.js')).default;
+
+let server;
+let baseURL;
+
+function testDoc() {
+  return {
+    room_id: '00000000-0000-0000-0000-000000000001',
+    round_id: '00000000-0000-0000-0000-000000000002',
+    author_id: '00000000-0000-0000-0000-000000000003',
+    phase: 'submit',
+    // Use a plausible future timestamp (ms) to avoid epoch edge cases
+    deadline_unix: 1700000000000,
+    content: 'Hello provenance',
+    claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
+    citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+    client_nonce: 'nonce-12345678'
+  };
+}
+
+beforeEach(async () => {
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, r));
+  baseURL = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+});
 
 describe('POST /rpc/provenance.verify', () => {
   it('verifies an Ed25519 signature over the canonicalized submission', async () => {
@@ -14,22 +43,7 @@ describe('POST /rpc/provenance.verify', () => {
     const pubDer = publicKey.export({ format: 'der', type: 'spki' });
     const public_key_b64 = Buffer.from(pubDer).toString('base64');
 
-    const doc = {
-      room_id: '00000000-0000-0000-0000-000000000001',
-      round_id: '00000000-0000-0000-0000-000000000002',
-      author_id: '00000000-0000-0000-0000-000000000003',
-      phase: 'submit',
-      deadline_unix: 0,
-      content: 'Hello provenance',
-      claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
-      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
-      client_nonce: 'nonce-12345678'
-    };
-
-    // Ask server to canonicalize internally, but we need the hash to sign
-    const server = http.createServer(app);
-    await new Promise((r) => server.listen(0, r));
-    const url = `http://127.0.0.1:${server.address().port}`;
+    const doc = testDoc();
     const canonicalizer =
       String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
         ? canonicalizeJCS
@@ -39,39 +53,83 @@ describe('POST /rpc/provenance.verify', () => {
       crypto.sign(null, Buffer.from(hashHex, 'hex'), privateKey)
     ).toString('base64');
 
-    const res = await fetch(url + '/rpc/provenance.verify', {
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ doc, signature_kind: 'ed25519', sig_b64, public_key_b64 })
     });
-    const body = await res.json().catch(() => ({}));
     expect(res.status).toBe(200);
+    const body = await res.json();
     expect(body?.ok).toBe(true);
     expect(typeof body?.hash).toBe('string');
-    await new Promise((r) => server.close(r));
+    expect(/^[0-9a-f]{64}$/.test(body.hash)).toBe(true);
   });
 
   it('returns 501 for SSH signatures (stub)', async () => {
-    const server = http.createServer(app);
-    await new Promise((r) => server.listen(0, r));
-    const url = `http://127.0.0.1:${server.address().port}`;
-    const doc = {
-      room_id: '00000000-0000-0000-0000-000000000001',
-      round_id: '00000000-0000-0000-0000-000000000002',
-      author_id: '00000000-0000-0000-0000-000000000003',
-      phase: 'submit',
-      deadline_unix: 0,
-      content: 'Hello',
-      claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
-      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
-      client_nonce: 'nonce-12345678'
-    };
-    const res = await fetch(url + '/rpc/provenance.verify', {
+    const doc = testDoc();
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ doc, signature_kind: 'ssh', sig_b64: 'x' })
     });
     expect(res.status).toBe(501);
-    await new Promise((r) => server.close(r));
+    const body = await res.json();
+    expect(body?.ok).toBe(false);
+    expect(typeof body?.error).toBe('string');
   });
+
+  it('400 when missing public_key_b64 for ed25519', async () => {
+    const doc = testDoc();
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc, signature_kind: 'ed25519', sig_b64: 'abc' })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body?.error).toBe('missing_public_key_b64');
+  });
+
+  it('400 for invalid public_key_b64', async () => {
+    const doc = testDoc();
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        doc,
+        signature_kind: 'ed25519',
+        sig_b64: 'abc',
+        public_key_b64: 'not-a-key'
+      })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body?.error).toBe('invalid_public_key_or_signature');
+  });
+
+  it('400 for incorrect signature with valid key', async () => {
+    const { publicKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const public_key_b64 = Buffer.from(pubDer).toString('base64');
+    const doc = testDoc();
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        doc,
+        signature_kind: 'ed25519',
+        sig_b64: Buffer.from('bad').toString('base64'),
+        public_key_b64
+      })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body?.error).toBe('invalid_public_key_or_signature');
+  });
+});
+
+// Restore env after module
+afterEach(() => {
+  if (originalDbUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = originalDbUrl;
 });

--- a/server/test/rpc.submission_create.test.js
+++ b/server/test/rpc.submission_create.test.js
@@ -1,7 +1,8 @@
 /* eslint-disable import/first */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import request from 'supertest';
 // Force in-memory path for this test to avoid DB coupling
+const __origDbUrl = process.env.DATABASE_URL;
 process.env.DATABASE_URL = '';
 const app = (await import('../rpc.js')).default;
 import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
@@ -32,4 +33,9 @@ describe('POST /rpc/submission.create', () => {
     expect(r1.body.submission_id).toEqual(r2.body.submission_id);
     expect(r1.body.canonical_sha256).toEqual(expected);
   });
+});
+
+afterAll(() => {
+  if (__origDbUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = __origDbUrl;
 });


### PR DESCRIPTION
Summary
- Return 400 for invalid signatures; include public_key_fingerprint for caller binding; optional DB author_binding using participants.ssh_fingerprint.
- Tighten SubmissionVerify schema (max lengths) and accept signature_b64 alias.
- Refactor tests: avoid server leaks with try/finally hooks; add error-path coverage; use realistic future deadline.
- Restore env after rpc.submission_create.test to avoid cross-test pollution.

Security
- This mitigates the core flaw called out in #126 by making it explicit which key verified (fingerprint), and by reporting DB author binding when configured. Full author-key registry enforcement can follow in a subsequent change.

Changes
- server/rpc.js, server/schemas.js, server/test/provenance.verify.test.js, server/test/rpc.submission_create.test.js

Tests
- Added failing-path tests and stronger hash validation; all tests pass locally.

Next
- Enforce author key binding when participants.ssh_fingerprint is populated; reject mismatch by default (feature flag gated).

Refs: Feedback on #126