### PR TITLE
chore(canon): flip default canonicalization to JCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ lastUpdated: 2025-10-04
 ## 2025-10-04 — PR #118 merged (M2 foundations)
 
 - Canonicalization
-  - Added RFC 8785 JCS behind `CANON_MODE=jcs`; default remains `sorted` for compatibility.
+  - Adopt RFC 8785 JCS as the default (`CANON_MODE=jcs`). Legacy `sorted` remains available for compatibility.
 - Nonces (server-issued)
   - Atomic DB path via `submission_upsert_with_nonce(...)` to consume-and-insert in one step.
   - Clear fallbacks: `invalid_nonce` → 400; otherwise log DB error and fall back to memory (when enabled) with TTL + single-use semantics.

--- a/bin/db8.js
+++ b/bin/db8.js
@@ -204,7 +204,7 @@ async function main() {
 
   function canonicalize(value) {
     const mode = String(
-      process.env.DB8_CANON_MODE || process.env.CANON_MODE || 'sorted'
+      process.env.DB8_CANON_MODE || process.env.CANON_MODE || 'jcs'
     ).toLowerCase();
     if (mode === 'jcs') return canonicalizePkg(value);
     const seen = new WeakSet();

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: 2025-10-02
+lastUpdated: 2025-10-05
 ---
 
 # CLI Specification (db8)
@@ -102,6 +102,7 @@ Journal & Verify
   - Downloads signed journal artifacts for room/round
 - db8 journal verify [--round <idx>]
   - Verifies round.chain.sig and per-submission signatures
+  - On success, prints ok; on failure prints fail and exits non‑zero.
 
 Agent QoL (batch)
 
@@ -125,6 +126,7 @@ Headers & Provenance
 - Authorization: Bearer <JWT>
 - X-DB8-Client-Nonce: <id> (also in body)
 - If --sign: attach ssh_sig (+ cert optional)
+- Verification: server returns `public_key_fingerprint` and enforces author binding when `participants.ssh_fingerprint` is configured (mismatch → 400).
 
 CLI UX Rules
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: 2025-10-04
+lastUpdated: 2025-10-05
 ---
 
 # Getting Started
@@ -46,7 +46,7 @@ node server/rpc.js   # listens on :3000
 
 Environment flags (M2)
 
-- `CANON_MODE=sorted|jcs` — switch canonicalization mode (RFC 8785 when `jcs`).
+- `CANON_MODE=sorted|jcs` — switch canonicalization mode (default is `jcs`, RFC 8785).
 - `ENFORCE_SERVER_NONCES=1` — require server-issued nonces for submissions.
 - `SIGNING_PRIVATE_KEY` / `SIGNING_PUBLIC_KEY` — PEM Ed25519 keypair to sign
   journals (dev keypair is generated if unset).

--- a/docs/LocalDB.md
+++ b/docs/LocalDB.md
@@ -142,8 +142,8 @@ curl <http://localhost:3000/health>
 These flags gate new M2 capabilities and are read by the server and CLI.
 
 - `CANON_MODE=sorted|jcs`
-  - `sorted` (default): stable, legacy sorted-keys canonicalization.
-  - `jcs`: RFC 8785 JSON Canonicalization Scheme (recommended for provenance).
+  - `jcs` (default): RFC 8785 JSON Canonicalization Scheme (recommended for provenance).
+  - `sorted`: legacy sorted-keys canonicalization (temporary compatibility mode).
 - `ENFORCE_SERVER_NONCES=1`
   - When set, the API enforces single-use server-issued nonces for submissions.
   - Issue a nonce via `POST /rpc/nonce.issue` and include it as `client_nonce` in

--- a/docs/LocalDB.md
+++ b/docs/LocalDB.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: 2025-10-04
+lastUpdated: 2025-10-05
 ---
 
 # Local Database Setup (Postgres / Supabase)
@@ -167,6 +167,14 @@ signature. You can fetch and verify them via HTTP or the CLI.
     - Memory: returns the synthesized latest only when `idx` equals the latest
       round; otherwise `404`.
   - `GET /journal/history?room_id=<uuid>` — ordered list of stored journals.
+
+### Provenance verification and author binding (M2)
+
+`POST /rpc/provenance.verify` canonicalizes the provided document using the server’s `CANON_MODE` and verifies Ed25519 signatures.
+
+- On success, returns `{ ok: true, hash, public_key_fingerprint }` where the fingerprint is `sha256:<hex>` of the DER‑encoded public key. If a participant fingerprint is configured (see below), response also includes `author_binding: "match"`.
+- Strict author binding: if the participant row has `ssh_fingerprint` populated, the fingerprint used to verify MUST match. On mismatch the server returns `400 { ok:false, error:"author_binding_mismatch", expected_fingerprint, got_fingerprint }`.
+- Store the expected fingerprint in `participants.ssh_fingerprint`. Preferred format: `sha256:<hex>`; if plain hex is provided, the server normalizes to `sha256:<hex>` for comparison.
 
 - CLI
   - `db8 journal:verify --room <uuid>` — verifies the latest journal signature

--- a/server/config/config-builder.js
+++ b/server/config/config-builder.js
@@ -32,7 +32,7 @@ export class ConfigBuilder {
   }
 
   build() {
-    const canonRaw = this._str('CANON_MODE', 'sorted');
+    const canonRaw = this._str('CANON_MODE', 'jcs');
     const canon = String(canonRaw || 'sorted').toLowerCase();
     const allowed = new Set(['sorted', 'jcs']);
     if (!allowed.has(canon)) {

--- a/server/test/provenance.verify.binding.test.js
+++ b/server/test/provenance.verify.binding.test.js
@@ -54,7 +54,7 @@ describe('provenance.verify author binding (DB)', () => {
     __setDbPool(makeStubPool(expectedFp));
 
     const canonicalizer =
-      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+      String(process.env.CANON_MODE || 'jcs').toLowerCase() === 'jcs'
         ? canonicalizeJCS
         : canonicalizeSorted;
     const hashHex = sha256Hex(canonicalizer(doc));
@@ -83,7 +83,7 @@ describe('provenance.verify author binding (DB)', () => {
     __setDbPool(makeStubPool(wrong));
 
     const canonicalizer =
-      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+      String(process.env.CANON_MODE || 'jcs').toLowerCase() === 'jcs'
         ? canonicalizeJCS
         : canonicalizeSorted;
     const hashHex = sha256Hex(canonicalizer(doc));

--- a/server/test/provenance.verify.binding.test.js
+++ b/server/test/provenance.verify.binding.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import app, { __setDbPool } from '../rpc.js';
+import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
+
+let server;
+let baseURL;
+
+function testDoc() {
+  return {
+    room_id: '00000000-0000-0000-0000-00000000b001',
+    round_id: '00000000-0000-0000-0000-00000000b002',
+    author_id: '00000000-0000-0000-0000-00000000b003',
+    phase: 'submit',
+    deadline_unix: 1700000000000,
+    content: 'Hello provenance',
+    claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
+    citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+    client_nonce: 'nonce-12345678'
+  };
+}
+
+function makeStubPool(fingerprint) {
+  return {
+    async query(text, _params) {
+      if (/select\s+ssh_fingerprint\s+from\s+participants/i.test(String(text))) {
+        return { rows: [{ ssh_fingerprint: fingerprint }] };
+      }
+      return { rows: [] };
+    }
+  };
+}
+
+beforeEach(async () => {
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, r));
+  baseURL = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+  __setDbPool(null);
+});
+
+describe('provenance.verify author binding (DB)', () => {
+  it('200 when fingerprint matches participants.ssh_fingerprint', async () => {
+    const doc = testDoc();
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const public_key_b64 = Buffer.from(pubDer).toString('base64');
+    const expectedFp = `sha256:${crypto.createHash('sha256').update(pubDer).digest('hex')}`;
+    __setDbPool(makeStubPool(expectedFp));
+
+    const canonicalizer =
+      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+        ? canonicalizeJCS
+        : canonicalizeSorted;
+    const hashHex = sha256Hex(canonicalizer(doc));
+    const sig_b64 = Buffer.from(
+      crypto.sign(null, Buffer.from(hashHex, 'hex'), privateKey)
+    ).toString('base64');
+
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc, signature_kind: 'ed25519', sig_b64, public_key_b64 })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body?.ok).toBe(true);
+    expect(body?.public_key_fingerprint).toBe(expectedFp);
+    expect(body?.author_binding).toBe('match');
+  });
+
+  it('400 when fingerprint mismatches participants.ssh_fingerprint', async () => {
+    const doc = testDoc();
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const public_key_b64 = Buffer.from(pubDer).toString('base64');
+    const wrong = 'sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    __setDbPool(makeStubPool(wrong));
+
+    const canonicalizer =
+      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+        ? canonicalizeJCS
+        : canonicalizeSorted;
+    const hashHex = sha256Hex(canonicalizer(doc));
+    const sig_b64 = Buffer.from(
+      crypto.sign(null, Buffer.from(hashHex, 'hex'), privateKey)
+    ).toString('base64');
+
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc, signature_kind: 'ed25519', sig_b64, public_key_b64 })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body?.error).toBe('author_binding_mismatch');
+    expect(typeof body?.expected_fingerprint).toBe('string');
+    expect(typeof body?.got_fingerprint).toBe('string');
+  });
+});

--- a/server/test/provenance.verify.test.js
+++ b/server/test/provenance.verify.test.js
@@ -45,7 +45,7 @@ describe('POST /rpc/provenance.verify', () => {
 
     const doc = testDoc();
     const canonicalizer =
-      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+      String(process.env.CANON_MODE || 'jcs').toLowerCase() === 'jcs'
         ? canonicalizeJCS
         : canonicalizeSorted;
     const hashHex = sha256Hex(canonicalizer(doc));

--- a/server/test/rpc.db.postgres.test.js
+++ b/server/test/rpc.db.postgres.test.js
@@ -73,7 +73,7 @@ suite('Postgres-backed RPC integration', () => {
       client_nonce: 'pg-nonce-1234'
     };
     const canonicalizer =
-      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+      String(process.env.CANON_MODE || 'jcs').toLowerCase() === 'jcs'
         ? canonicalizeJCS
         : canonicalizeSorted;
     const canon = canonicalizer(body);

--- a/server/test/rpc.submission_create.test.js
+++ b/server/test/rpc.submission_create.test.js
@@ -21,7 +21,7 @@ describe('POST /rpc/submission.create', () => {
       client_nonce: 'abc123456'
     };
     const canonicalizer =
-      String(process.env.CANON_MODE || 'sorted').toLowerCase() === 'jcs'
+      String(process.env.CANON_MODE || 'jcs').toLowerCase() === 'jcs'
         ? canonicalizeJCS
         : canonicalizeSorted;
     const canon = canonicalizer(body);

--- a/server/watcher.js
+++ b/server/watcher.js
@@ -19,7 +19,7 @@ export async function runTick(pool) {
 const _signer = createSigner({
   privateKeyPem: process.env.SIGNING_PRIVATE_KEY || '',
   publicKeyPem: process.env.SIGNING_PUBLIC_KEY || '',
-  canonMode: process.env.CANON_MODE || 'sorted'
+  canonMode: process.env.CANON_MODE || 'jcs'
 });
 
 async function signPublished(pool) {


### PR DESCRIPTION
Summary
- Server/CLI default CANON_MODE=jcs (RFC 8785) for deterministic cross-runtime canonicalization.
- Tests default to jcs when env is unset; docs and changelog updated.

Changes
- server/config/config-builder.js, server/watcher.js: defaults to jcs
- bin/db8.js: CLI default canonicalize uses jcs
- tests: assume jcs when CANON_MODE is unset
- docs: GettingStarted/LocalDB reflect default jcs
- CHANGELOG: note adoption

Next
- Monitor downstream clients; legacy 'sorted' remains available via CANON_MODE=sorted.

