### PR TITLE
feat(provenance): participant fingerprint enrollment (DB/API/CLI)

### DIFF
--- a/bin/db8.js
+++ b/bin/db8.js
@@ -93,7 +93,8 @@ async function main() {
       'flag:submission',
       'journal:pull',
       'journal:verify',
-      'provenance:verify'
+      'provenance:verify',
+      'provenance:enroll'
     ]);
 
     // Help handling
@@ -876,6 +877,54 @@ async function main() {
         if (args.json) print(JSON.stringify({ ok }));
         else print(ok ? 'ok' : 'fail');
         return ok ? EXIT.OK : EXIT.VALIDATION;
+      } catch (e) {
+        printerr(e?.message || String(e));
+        return EXIT.NETWORK;
+      }
+    }
+    case 'provenance:enroll': {
+      const participantId = args.participant || process.env.DB8_PARTICIPANT_ID || '';
+      if (!participantId) {
+        printerr('provenance enroll requires --participant <uuid>');
+        return EXIT.VALIDATION;
+      }
+      const pubB64 = args['pub-b64'];
+      const fpArg = args.fp || args.fingerprint;
+      if ((!pubB64 && !fpArg) || (pubB64 && fpArg)) {
+        printerr('provide exactly one of --pub-b64 <DER base64> or --fp sha256:<hex>');
+        return EXIT.VALIDATION;
+      }
+      let body;
+      if (pubB64) {
+        body = { participant_id: participantId, public_key_b64: String(pubB64) };
+      } else {
+        const fpNorm = String(fpArg).toLowerCase();
+        if (!/^(sha256:)?[0-9a-f]{64}$/.test(fpNorm)) {
+          printerr('invalid fingerprint format (expect sha256:<64 hex> or 64 hex)');
+          return EXIT.VALIDATION;
+        }
+        body = { participant_id: participantId, fingerprint: fpNorm };
+      }
+      try {
+        const url = `${apiUrl.replace(/\/$/, '')}/rpc/participant.fingerprint.set`;
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            ...(jwt ? { authorization: `Bearer ${jwt}` } : {})
+          },
+          body: JSON.stringify(body)
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data?.ok) {
+          if (args.json)
+            print(JSON.stringify({ ok: false, status: res.status, error: data?.error }));
+          else printerr(data?.error || `Server error ${res.status}`);
+          return EXIT.PROVENANCE;
+        }
+        if (args.json) print(JSON.stringify({ ok: true, fingerprint: data.fingerprint }));
+        else print(data.fingerprint);
+        return EXIT.OK;
       } catch (e) {
         printerr(e?.message || String(e));
         return EXIT.NETWORK;

--- a/cspell.json
+++ b/cspell.json
@@ -93,7 +93,9 @@
     "scoringandreputation",
     "researchtools",
     "attributioncontrol",
-    "orchestratorheartbeat"
+    "orchestratorheartbeat",
+    "SPKI",
+    "spki"
   ],
   "ignoreWords": ["frontmatter", "Frontmatter"]
 }

--- a/db/test/31_participants_enrollment.pgtap
+++ b/db/test/31_participants_enrollment.pgtap
@@ -1,0 +1,60 @@
+-- 31_participants_enrollment.pgtap — fingerprint enrollment normalization and checks
+BEGIN;
+SELECT plan(6);
+
+-- Seed a room, round, and participant
+SELECT diag('seeding room/round/participant');
+INSERT INTO rooms(id, title) VALUES ('00000000-0000-0000-0000-00000000aa00', 't');
+INSERT INTO rounds(id, room_id, idx, phase, submit_deadline_unix)
+VALUES ('00000000-0000-0000-0000-00000000aa01', '00000000-0000-0000-0000-00000000aa00', 0, 'submit', 0);
+INSERT INTO participants(id, room_id, anon_name, role)
+VALUES ('00000000-0000-0000-0000-00000000aa02', '00000000-0000-0000-0000-00000000aa00', 'p1', 'debater');
+
+-- 1) Accept explicit sha256:<hex>
+SELECT diag('explicit sha256: hex');
+SELECT is(
+  participant_fingerprint_set('00000000-0000-0000-0000-00000000aa02', 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+  'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'returns normalized prefixed fingerprint'
+);
+SELECT is(
+  (SELECT ssh_fingerprint FROM participants WHERE id = '00000000-0000-0000-0000-00000000aa02'),
+  'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'participants.ssh_fingerprint updated'
+);
+
+-- 2) Accept plain hex and normalize to sha256:
+SELECT diag('plain hex normalization');
+SELECT like(
+  participant_fingerprint_set('00000000-0000-0000-0000-00000000aa02', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+  'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  'plain hex normalized with prefix'
+);
+
+-- 3) Accept base64 and compute digest over decoded bytes
+SELECT diag('base64 input');
+SELECT is(
+  participant_fingerprint_set('00000000-0000-0000-0000-00000000aa02', 'AQIDBA=='),
+  'sha256:' || encode(digest(decode('AQIDBA==','base64'), 'sha256'), 'hex'),
+  'base64 decoded and hashed'
+);
+
+-- 4) Invalid input rejected
+SELECT throws_ok(
+  $$ SELECT participant_fingerprint_set('00000000-0000-0000-0000-00000000aa02', 'not-a-key'); $$,
+  '22023',
+  'invalid_fingerprint_or_key',
+  'rejects invalid format'
+);
+
+-- 5) Non-existent participant rejected
+SELECT throws_ok(
+  $$ SELECT participant_fingerprint_set('00000000-0000-0000-0000-00000000aa09', 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'); $$,
+  '22023',
+  'participant_not_found',
+  'rejects unknown participant'
+);
+
+SELECT finish();
+ROLLBACK;
+

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -114,6 +114,19 @@ Journals
   synthesized latest in memory mode)
 - `GET /journal/history?room_id=<uuid>` — list of journals (for history pages / CLI verify)
 
+Enrollment (author binding)
+
+- Enroll a participant fingerprint so provenance verify can bind authorship:
+
+```bash
+# DER SPKI (Base64) example
+PUB_B64="$(node -e "const c=require('crypto');const {publicKey}=c.generateKeyPairSync('ed25519');console.log(Buffer.from(publicKey.export({format:'der',type:'spki'})).toString('base64'))")"
+db8 provenance enroll --participant <participant-uuid> --pub-b64 "$PUB_B64"
+
+# Or enroll a known fingerprint (sha256:<64-hex>)
+db8 provenance enroll --participant <participant-uuid> --fp sha256:<hex>
+```
+
 ## Run tests
 
 ```bash

--- a/server/schemas.js
+++ b/server/schemas.js
@@ -85,3 +85,33 @@ export const SubmissionVerify = z
     message: 'missing_signature',
     path: ['sig_b64']
   });
+
+// Participant fingerprint enrollment
+export const ParticipantFingerprintSet = z
+  .object({
+    participant_id: z.string().uuid(),
+    public_key_b64: z.string().optional(),
+    fingerprint: z.string().optional()
+  })
+  .refine(
+    (v) => {
+      const a = Boolean(v.public_key_b64);
+      const b = Boolean(v.fingerprint);
+      return (a || b) && !(a && b);
+    },
+    {
+      message: 'provide_exactly_one_of_public_key_b64_or_fingerprint',
+      path: ['public_key_b64']
+    }
+  )
+  .refine(
+    (v) => {
+      if (v.fingerprint === undefined) return true;
+      const s = String(v.fingerprint).toLowerCase();
+      return /^(sha256:)?[0-9a-f]{64}$/.test(s);
+    },
+    {
+      message: 'invalid_fingerprint_format',
+      path: ['fingerprint']
+    }
+  );

--- a/server/test/cli.provenance.enroll.test.js
+++ b/server/test/cli.provenance.enroll.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import http from 'node:http';
+
+let app;
+let server;
+let baseURL;
+
+function runCli(args, env = {}) {
+  return new Promise((resolve) => {
+    const bin = path.resolve('bin/db8.js');
+    const p = spawn('node', [bin, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    let out = '';
+    let err = '';
+    p.stdout.on('data', (d) => (out += String(d)));
+    p.stderr.on('data', (d) => (err += String(d)));
+    p.on('close', (code) => resolve({ code, out: out.trim(), err: err.trim() }));
+  });
+}
+
+beforeEach(async () => {
+  process.env.DATABASE_URL = '';
+  const mod = await import('../rpc.js');
+  app = mod.default;
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, r));
+  baseURL = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+  delete process.env.DATABASE_URL;
+});
+
+describe('CLI provenance enroll', () => {
+  it('enrolls with --pub-b64 and prints normalized fingerprint', async () => {
+    const { publicKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const pubB64 = Buffer.from(pubDer).toString('base64');
+    const expected = 'sha256:' + crypto.createHash('sha256').update(pubDer).digest('hex');
+    const args = [
+      'provenance',
+      'enroll',
+      '--participant',
+      '00000000-0000-0000-0000-00000000ee01',
+      '--pub-b64',
+      pubB64
+    ];
+    const { code, out } = await runCli(args, { DB8_API_URL: baseURL });
+    expect(code).toBe(0);
+    expect(out).toBe(expected);
+  });
+});

--- a/server/test/participant.fingerprint.set.test.js
+++ b/server/test/participant.fingerprint.set.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+
+let app;
+let server;
+let baseURL;
+let __setDbPool;
+
+beforeEach(async () => {
+  // Use in-memory path to validate normalization and fallback behavior by default
+  process.env.DATABASE_URL = '';
+  const mod = await import('../rpc.js');
+  app = mod.default;
+  __setDbPool = mod.__setDbPool;
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, r));
+  baseURL = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+  __setDbPool(null);
+  delete process.env.DATABASE_URL;
+});
+
+describe('POST /rpc/participant.fingerprint.set', () => {
+  it('accepts DER SPKI base64 and returns normalized sha256:<hex>', async () => {
+    const { publicKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const public_key_b64 = Buffer.from(pubDer).toString('base64');
+    const expected = 'sha256:' + crypto.createHash('sha256').update(pubDer).digest('hex');
+
+    const res = await fetch(baseURL + '/rpc/participant.fingerprint.set', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        participant_id: '00000000-0000-0000-0000-00000000cc01',
+        public_key_b64
+      })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body?.ok).toBe(true);
+    expect(body?.fingerprint).toBe(expected);
+  });
+
+  it('accepts explicit fingerprint and normalizes case/prefix', async () => {
+    const res = await fetch(baseURL + '/rpc/participant.fingerprint.set', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        participant_id: '00000000-0000-0000-0000-00000000cc02',
+        fingerprint: 'AAAAAAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(/^sha256:[0-9a-f]{64}$/.test(body?.fingerprint)).toBe(true);
+  });
+
+  it('uses DB RPC when pool provided', async () => {
+    const calls = [];
+    const fake = {
+      async query(text, params) {
+        calls.push({ text, params });
+        if (/participant_fingerprint_set\(/i.test(String(text))) {
+          return {
+            rows: [
+              {
+                fingerprint: String(params[1]).startsWith('sha256:')
+                  ? params[1]
+                  : 'sha256:deadbeef'.padEnd(71, 'f')
+              }
+            ]
+          };
+        }
+        throw new Error('unexpected query');
+      }
+    };
+    __setDbPool(fake);
+    const res = await fetch(baseURL + '/rpc/participant.fingerprint.set', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        participant_id: '00000000-0000-0000-0000-00000000cc03',
+        fingerprint: 'sha256:' + 'b'.repeat(64)
+      })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body?.ok).toBe(true);
+    expect(body?.fingerprint).toBe('sha256:' + 'b'.repeat(64));
+    expect(calls[0].text).toMatch(/participant_fingerprint_set/i);
+  });
+});


### PR DESCRIPTION
Summary\n- Add participant fingerprint enrollment to enable strict author binding in provenance verification.\n\nChanges\n- DB: `participant_fingerprint_set(p_id uuid, p_input text) -> text` (accepts DER SPKI base64 or sha256:<hex>), normalizes to `sha256:<hex>`; CHECK constraint on `participants.ssh_fingerprint`; pgTAP tests.\n- API: `POST /rpc/participant.fingerprint.set` with Zod validation/normalization; uses DB RPC when configured, with memory fallback.\n- CLI: `db8 provenance enroll --participant <uuid> (--pub-b64 <DER>|--fp sha256:<hex>) [--json]`; prints normalized fingerprint.\n- Docs: GettingStarted adds brief enrollment instructions.\n\nTests\n- New pgTAP suite for enrollment normalization and rejections.\n- Vitest: API route happy path + DB call stub.\n- Vitest: CLI enroll command prints normalized fingerprint.\n\nNext\n- Wire optional `ENFORCE_AUTHOR_BINDING=1` to reject unenrolled authors.\n- Extend SSH verification path to accept OpenSSH keys.\n\nFixes #131