### PR TITLE
feat(server,db,web): SSE journal event (NOTIFY + badge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pnpm-debug.log*
 .pnpm-debug.log*
 .eslintcache
 .cache/
+.tmp*.prov*.json
 
 # Env files (keep an example committed separately)
 .env

--- a/.tmp.prov.doc.json
+++ b/.tmp.prov.doc.json
@@ -1,0 +1,11 @@
+{
+  "room_id": "00000000-0000-0000-0000-00000000dd01",
+  "round_id": "00000000-0000-0000-0000-00000000dd02",
+  "author_id": "00000000-0000-0000-0000-00000000dd03",
+  "phase": "submit",
+  "deadline_unix": 1700000000000,
+  "content": "Hello provenance",
+  "claims": [{ "id": "c1", "text": "Abc", "support": [{ "kind": "logic", "ref": "x" }] }],
+  "citations": [{ "url": "https://example.com/a" }, { "url": "https://example.com/b" }],
+  "client_nonce": "nonce-xyz"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -871,6 +871,31 @@ rationale and added a rule to separate event blocks with HRs in debriefs.
 - Docs: bump `lastUpdated` on every Markdown edit; append Agent Log entries after shipping.
 - CI: run docker-backed tests locally when touching DB or SSE paths; keep tests free of server leaks.
 
+---
+
+### Event — 2025-10-06 | Board Sync + M2 progress
+
+#### Summary
+
+- Merged #130 (docs), #132 (fingerprint enrollment DB/API/CLI), and #134 (CLI provenance verify UX). Updated project board to Done for #129/#131/#133.
+
+#### References
+
+- PRs: #130, #132, #134
+- Issues: #129 (closed via PR #130), #131 (closed via PR #132), #133 (closed via PR #134)
+
+#### Key Decisions
+
+- Close issues on merge and set Project Status/Workflow to Done immediately to keep hygiene tight.
+
+#### Action Items
+
+- Next tasks: Journal SSE event; optional `ENFORCE_AUTHOR_BINDING=1`; SSH path.
+
+#### Notes
+
+- CLI now prints fingerprint + binding in verify; JSON passthrough remains for tooling.
+
 #### Post‑compact Prompt (paste to rehydrate context)
 
 """

--- a/db/rpc.sql
+++ b/db/rpc.sql
@@ -422,6 +422,17 @@ BEGIN
   VALUES (p_room_id, p_round_idx, p_hash, COALESCE(p_signature, '{}'::jsonb), COALESCE(p_core, '{}'::jsonb))
   ON CONFLICT (room_id, round_idx)
   DO UPDATE SET hash = EXCLUDED.hash, signature = EXCLUDED.signature, core = EXCLUDED.core;
+
+  -- Notify listeners that a new/updated journal is available for this room/round
+  PERFORM pg_notify(
+    'db8_journal',
+    json_build_object(
+      't', 'journal',
+      'room_id', p_room_id::text,
+      'idx', p_round_idx,
+      'hash', p_hash
+    )::text
+  );
 END;
 $$;
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -96,6 +96,22 @@ Endpoints (canonical realtime = SSE):
   }
   ```
 
+  - event: journal (emitted on DB NOTIFY from `journal_upsert`)
+    - t: "journal"
+    - room_id: string (uuid)
+    - idx: number (round index)
+    - hash: string (sha256 of the journal core)
+    - Example frame:
+
+  ```json
+  {
+    "t": "journal",
+    "room_id": "00000000-0000-0000-0000-0000000000ab",
+    "idx": 0,
+    "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  }
+  ```
+
   - Errors
     - HTTP error responses: 4xx/5xx with JSON body `{ ok:false, error:string }`
   - SSE connection guidance: use EventSource with default retry;

--- a/server/test/sse.db.events.test.js
+++ b/server/test/sse.db.events.test.js
@@ -1,8 +1,7 @@
 import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import http from 'node:http';
 import { Pool } from 'pg';
-import fs from 'node:fs';
-import path from 'node:path';
+// schema/rpc/rls are prepared by scripts/prepare-db.js before test run
 import app, { __setDbPool } from '../rpc.js';
 
 const shouldRun =
@@ -25,14 +24,7 @@ suite('SSE /events is DB-backed (LISTEN/NOTIFY)', () => {
     pool = new Pool({ connectionString: dbUrl });
     __setDbPool(pool);
 
-    // Load schema + RPCs if missing (avoid concurrent redefine races)
-    // Load schema/RPC/RLS always to keep deterministic
-    const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
-    await pool.query(schemaSql);
-    const rpcSql = fs.readFileSync(path.resolve('db/rpc.sql'), 'utf8');
-    await pool.query(rpcSql);
-    const rlsSql = fs.readFileSync(path.resolve('db/rls.sql'), 'utf8');
-    await pool.query(rlsSql);
+    // Schema/RPC/RLS are loaded by scripts/prepare-db.js prior to tests.
 
     // Create a room/round via RPC and fetch the current round via the secure view
     const rc = await pool.query('select room_create($1) as id', ['SSE Test Room']);

--- a/server/test/sse.db.journal.test.js
+++ b/server/test/sse.db.journal.test.js
@@ -96,5 +96,5 @@ suite('SSE /events emits journal on DB NOTIFY', () => {
     expect(got.room_id).toBe(roomId);
     expect(got.idx).toBe(0);
     expect(got.hash).toBe(expectedHash);
-  }, 6000);
+  }, 3000);
 });

--- a/server/test/sse.db.journal.test.js
+++ b/server/test/sse.db.journal.test.js
@@ -1,0 +1,100 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
+import http from 'node:http';
+import { Pool } from 'pg';
+// schema/rpc/rls are prepared by scripts/prepare-db.js before test run
+import app, { __setDbPool } from '../rpc.js';
+
+const shouldRun =
+  process.env.RUN_PGTAP === '1' ||
+  process.env.DB8_TEST_PG === '1' ||
+  process.env.DB8_TEST_DATABASE_URL;
+const dbUrl =
+  process.env.DB8_TEST_DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8_test';
+
+const suite = shouldRun ? describe : describe.skip;
+
+suite('SSE /events emits journal on DB NOTIFY', () => {
+  let pool;
+  let server;
+  let port;
+  let roomId;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: dbUrl });
+    __setDbPool(pool);
+
+    // Schema/RPC/RLS are loaded by scripts/prepare-db.js prior to tests.
+
+    const rc = await pool.query('select room_create($1) as id', ['Journal SSE Room']);
+    roomId = rc.rows[0].id;
+
+    server = http.createServer(app);
+    await new Promise((r) => server.listen(0, r));
+    port = server.address().port;
+  });
+
+  afterAll(async () => {
+    __setDbPool(null);
+    if (server) await new Promise((r) => server.close(r));
+    if (pool) await pool.end();
+  });
+
+  it('receives a journal event after journal_upsert', async () => {
+    const sseUrl = `http://127.0.0.1:${port}/events?room_id=${encodeURIComponent(roomId)}`;
+    const expectedHash = 'f'.repeat(64);
+
+    const got = await new Promise((resolve, reject) => {
+      const req = http.request(
+        sseUrl,
+        { method: 'GET', headers: { accept: 'text/event-stream' } },
+        (res) => {
+          res.setEncoding('utf8');
+          let buf = '';
+          let sawTimer = false;
+          const onData = async (chunk) => {
+            buf += chunk;
+            let idx;
+            while ((idx = buf.indexOf('\n\n')) !== -1) {
+              const frame = buf.slice(0, idx);
+              buf = buf.slice(idx + 2);
+              const evLine = frame.split('\n').find((l) => l.startsWith('event: '));
+              const dataLine = frame.split('\n').find((l) => l.startsWith('data: '));
+              if (!dataLine) continue;
+              const type = evLine ? evLine.slice(7).trim() : 'message';
+              const payload = JSON.parse(dataLine.slice(6));
+              if (!sawTimer && payload.t === 'timer') {
+                sawTimer = true;
+                try {
+                  await pool.query('select journal_upsert($1,$2,$3,$4::jsonb,$5::jsonb)', [
+                    roomId,
+                    0,
+                    expectedHash,
+                    JSON.stringify({}),
+                    JSON.stringify({ idx: 0 })
+                  ]);
+                } catch (e) {
+                  res.off('data', onData);
+                  res.destroy();
+                  return reject(e);
+                }
+              }
+              if (type === 'journal' && payload.t === 'journal' && payload.room_id === roomId) {
+                res.off('data', onData);
+                res.destroy();
+                return resolve(payload);
+              }
+            }
+          };
+          res.on('data', onData);
+          res.on('error', reject);
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(got.room_id).toBe(roomId);
+    expect(got.idx).toBe(0);
+    expect(got.hash).toBe(expectedHash);
+  }, 6000);
+});

--- a/web/app/room/[roomId]/page.jsx
+++ b/web/app/room/[roomId]/page.jsx
@@ -33,6 +33,7 @@ export default function RoomPage({ params }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [hasNewJournal, setHasNewJournal] = useState(false);
   const timerRef = useRef(null);
   const esRef = useRef(null);
   const lastNonceRef = useRef('');
@@ -71,6 +72,14 @@ export default function RoomPage({ params }) {
           void 0;
         }
       };
+      es.addEventListener('journal', (ev) => {
+        try {
+          const d = JSON.parse(ev.data);
+          if (d && d.t === 'journal' && d.room_id === roomId) setHasNewJournal(true);
+        } catch {
+          /* ignore */
+        }
+      });
       es.onerror = () => {
         try {
           es.close();
@@ -318,13 +327,14 @@ export default function RoomPage({ params }) {
             <div className="text-lg font-semibold">Transcript</div>
             <Badge variant="outline">{transcript.length} entries</Badge>
           </div>
-          <div className="text-sm">
+          <div className="text-sm flex items-center gap-3">
             <Link
               className="underline text-[color:var(--teal)]"
               href={`/journal/${encodeURIComponent(roomId)}`}
             >
               View journal history →
             </Link>
+            {hasNewJournal && <Badge variant="success">New checkpoint</Badge>}
           </div>
           {transcript.length === 0 ? (
             <p className="text-sm text-muted">No submissions yet.</p>

--- a/web/app/room/[roomId]/page.jsx
+++ b/web/app/room/[roomId]/page.jsx
@@ -331,6 +331,7 @@ export default function RoomPage({ params }) {
             <Link
               className="underline text-[color:var(--teal)]"
               href={`/journal/${encodeURIComponent(roomId)}`}
+              onClick={() => setHasNewJournal(false)}
             >
               View journal history →
             </Link>


### PR DESCRIPTION
Summary\n- Add pg_notify('db8_journal', ...) from journal_upsert.\n- /events now LISTENs 'db8_journal' and emits event: journal frames.\n- Web Room page shows a 'New checkpoint' badge when a journal is emitted.\n\nChanges\n- db/rpc.sql: pg_notify in journal_upsert.\n- server/rpc.js: LISTEN db8_journal; emit event: journal.\n- server/test/sse.db.journal.test.js: DB-backed SSE test.\n- web/app/room/[roomId]/page.jsx: add SSE listener + badge UI.\n- docs/GettingStarted.md: document event: journal frame.\n\nTests\n- Vitest integration for NOTIFY → SSE event green and stable.\n\nNext\n- ENFORCE_AUTHOR_BINDING flag; SSH pubkey verification path.\n\nFixes #135