### PR TITLE
feat(server): ENFORCE_AUTHOR_BINDING for provenance

### DIFF
--- a/.tmp.prov.doc.json
+++ b/.tmp.prov.doc.json
@@ -1,0 +1,11 @@
+{
+  "room_id": "00000000-0000-0000-0000-00000000dd01",
+  "round_id": "00000000-0000-0000-0000-00000000dd02",
+  "author_id": "00000000-0000-0000-0000-00000000dd03",
+  "phase": "submit",
+  "deadline_unix": 1700000000000,
+  "content": "Hello provenance",
+  "claims": [{ "id": "c1", "text": "Abc", "support": [{ "kind": "logic", "ref": "x" }] }],
+  "citations": [{ "url": "https://example.com/a" }, { "url": "https://example.com/b" }],
+  "client_nonce": "nonce-xyz"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -871,6 +871,31 @@ rationale and added a rule to separate event blocks with HRs in debriefs.
 - Docs: bump `lastUpdated` on every Markdown edit; append Agent Log entries after shipping.
 - CI: run docker-backed tests locally when touching DB or SSE paths; keep tests free of server leaks.
 
+---
+
+### Event — 2025-10-06 | Board Sync + M2 progress
+
+#### Summary
+
+- Merged #130 (docs), #132 (fingerprint enrollment DB/API/CLI), and #134 (CLI provenance verify UX). Updated project board to Done for #129/#131/#133.
+
+#### References
+
+- PRs: #130, #132, #134
+- Issues: #129 (closed via PR #130), #131 (closed via PR #132), #133 (closed via PR #134)
+
+#### Key Decisions
+
+- Close issues on merge and set Project Status/Workflow to Done immediately to keep hygiene tight.
+
+#### Action Items
+
+- Next tasks: Journal SSE event; optional `ENFORCE_AUTHOR_BINDING=1`; SSH path.
+
+#### Notes
+
+- CLI now prints fingerprint + binding in verify; JSON passthrough remains for tooling.
+
 #### Post‑compact Prompt (paste to rehydrate context)
 
 """

--- a/db/rpc.sql
+++ b/db/rpc.sql
@@ -422,6 +422,17 @@ BEGIN
   VALUES (p_room_id, p_round_idx, p_hash, COALESCE(p_signature, '{}'::jsonb), COALESCE(p_core, '{}'::jsonb))
   ON CONFLICT (room_id, round_idx)
   DO UPDATE SET hash = EXCLUDED.hash, signature = EXCLUDED.signature, core = EXCLUDED.core;
+
+  -- Notify listeners that a new/updated journal is available for this room/round
+  PERFORM pg_notify(
+    'db8_journal',
+    json_build_object(
+      't', 'journal',
+      'room_id', p_room_id::text,
+      'idx', p_round_idx,
+      'hash', p_hash
+    )::text
+  );
 END;
 $$;
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -96,6 +96,22 @@ Endpoints (canonical realtime = SSE):
   }
   ```
 
+  - event: journal (emitted on DB NOTIFY from `journal_upsert`)
+    - t: "journal"
+    - room_id: string (uuid)
+    - idx: number (round index)
+    - hash: string (sha256 of the journal core)
+    - Example frame:
+
+  ```json
+  {
+    "t": "journal",
+    "room_id": "00000000-0000-0000-0000-0000000000ab",
+    "idx": 0,
+    "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  }
+  ```
+
   - Errors
     - HTTP error responses: 4xx/5xx with JSON body `{ ok:false, error:string }`
   - SSE connection guidance: use EventSource with default retry;

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -48,6 +48,8 @@ Environment flags (M2)
 
 - `CANON_MODE=sorted|jcs` — switch canonicalization mode (default is `jcs`, RFC 8785).
 - `ENFORCE_SERVER_NONCES=1` — require server-issued nonces for submissions.
+- `ENFORCE_AUTHOR_BINDING=1` — require an enrolled fingerprint for the claimed author_id during provenance verify;
+  if missing, `/rpc/provenance.verify` returns `400 { ok:false, error:"author_not_configured" }`.
 - `SIGNING_PRIVATE_KEY` / `SIGNING_PUBLIC_KEY` — PEM Ed25519 keypair to sign
   journals (dev keypair is generated if unset).
 

--- a/server/config/config-builder.js
+++ b/server/config/config-builder.js
@@ -45,6 +45,7 @@ export class ConfigBuilder {
       databaseUrl: this._str('DATABASE_URL', ''),
       canonMode: canon,
       enforceServerNonces: this._bool('ENFORCE_SERVER_NONCES', false),
+      enforceAuthorBinding: this._bool('ENFORCE_AUTHOR_BINDING', false),
       enforceRateLimit: this._bool('ENFORCE_RATELIMIT', false),
       submitWindowSec: this._int('SUBMIT_WINDOW_SEC', 300),
       continueWindowSec: this._int('CONTINUE_WINDOW_SEC', 30)

--- a/server/test/provenance.verify.enforce.test.js
+++ b/server/test/provenance.verify.enforce.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
+
+let app;
+let __setDbPool;
+let server;
+let baseURL;
+
+function testDoc() {
+  return {
+    room_id: '00000000-0000-0000-0000-00000000e001',
+    round_id: '00000000-0000-0000-0000-00000000e002',
+    author_id: '00000000-0000-0000-0000-00000000e003',
+    phase: 'submit',
+    deadline_unix: 1700000000000,
+    content: 'Hello provenance',
+    claims: [{ id: 'c1', text: 'Abc', support: [{ kind: 'logic', ref: 'x' }] }],
+    citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+    client_nonce: 'nonce-abcdef01'
+  };
+}
+
+function makeStubPool(nullFingerprint = true) {
+  return {
+    async query(text, _params) {
+      if (/select\s+ssh_fingerprint\s+from\s+participants/i.test(String(text))) {
+        return { rows: [{ ssh_fingerprint: nullFingerprint ? null : 'sha256:' + 'a'.repeat(64) }] };
+      }
+      return { rows: [] };
+    }
+  };
+}
+
+const __origDbUrl = process.env.DATABASE_URL;
+const __origEnforce = process.env.ENFORCE_AUTHOR_BINDING;
+
+describe('provenance.verify enforcement (author binding required)', () => {
+  beforeEach(async () => {
+    process.env.DATABASE_URL = '';
+    process.env.ENFORCE_AUTHOR_BINDING = '1';
+    const mod = await import('../rpc.js');
+    app = mod.default;
+    __setDbPool = mod.__setDbPool;
+    server = http.createServer(app);
+    await new Promise((r) => server.listen(0, r));
+    baseURL = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise((r) => server.close(r));
+    __setDbPool(null);
+    if (__origDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = __origDbUrl;
+    if (__origEnforce === undefined) delete process.env.ENFORCE_AUTHOR_BINDING;
+    else process.env.ENFORCE_AUTHOR_BINDING = __origEnforce;
+  });
+
+  it('400 author_not_configured when fingerprint not enrolled and enforcement enabled', async () => {
+    __setDbPool(makeStubPool(true));
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const pubDer = publicKey.export({ format: 'der', type: 'spki' });
+    const public_key_b64 = Buffer.from(pubDer).toString('base64');
+    const doc = testDoc();
+    const canonicalizer =
+      String(process.env.CANON_MODE || 'jcs').toLowerCase() === 'jcs'
+        ? canonicalizeJCS
+        : canonicalizeSorted;
+    const hashHex = sha256Hex(canonicalizer(doc));
+    const sig_b64 = Buffer.from(
+      crypto.sign(null, Buffer.from(hashHex, 'hex'), privateKey)
+    ).toString('base64');
+    const res = await fetch(baseURL + '/rpc/provenance.verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc, signature_kind: 'ed25519', sig_b64, public_key_b64 })
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body?.error).toBe('author_not_configured');
+  });
+
+  // Non-enforcement behavior is covered by other tests; module-level config caching
+  // makes toggling within a single file unreliable in ESM. This case is validated
+  // in baseline provenance.verify tests where author_binding === 'not_configured'.
+});

--- a/server/test/sse.db.events.test.js
+++ b/server/test/sse.db.events.test.js
@@ -1,8 +1,7 @@
 import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 import http from 'node:http';
 import { Pool } from 'pg';
-import fs from 'node:fs';
-import path from 'node:path';
+// schema/rpc/rls are prepared by scripts/prepare-db.js before test run
 import app, { __setDbPool } from '../rpc.js';
 
 const shouldRun =
@@ -25,14 +24,7 @@ suite('SSE /events is DB-backed (LISTEN/NOTIFY)', () => {
     pool = new Pool({ connectionString: dbUrl });
     __setDbPool(pool);
 
-    // Load schema + RPCs if missing (avoid concurrent redefine races)
-    // Load schema/RPC/RLS always to keep deterministic
-    const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
-    await pool.query(schemaSql);
-    const rpcSql = fs.readFileSync(path.resolve('db/rpc.sql'), 'utf8');
-    await pool.query(rpcSql);
-    const rlsSql = fs.readFileSync(path.resolve('db/rls.sql'), 'utf8');
-    await pool.query(rlsSql);
+    // Schema/RPC/RLS are loaded by scripts/prepare-db.js prior to tests.
 
     // Create a room/round via RPC and fetch the current round via the secure view
     const rc = await pool.query('select room_create($1) as id', ['SSE Test Room']);

--- a/server/test/sse.db.journal.test.js
+++ b/server/test/sse.db.journal.test.js
@@ -1,0 +1,100 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
+import http from 'node:http';
+import { Pool } from 'pg';
+// schema/rpc/rls are prepared by scripts/prepare-db.js before test run
+import app, { __setDbPool } from '../rpc.js';
+
+const shouldRun =
+  process.env.RUN_PGTAP === '1' ||
+  process.env.DB8_TEST_PG === '1' ||
+  process.env.DB8_TEST_DATABASE_URL;
+const dbUrl =
+  process.env.DB8_TEST_DATABASE_URL || 'postgresql://postgres:test@localhost:54329/db8_test';
+
+const suite = shouldRun ? describe : describe.skip;
+
+suite('SSE /events emits journal on DB NOTIFY', () => {
+  let pool;
+  let server;
+  let port;
+  let roomId;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: dbUrl });
+    __setDbPool(pool);
+
+    // Schema/RPC/RLS are loaded by scripts/prepare-db.js prior to tests.
+
+    const rc = await pool.query('select room_create($1) as id', ['Journal SSE Room']);
+    roomId = rc.rows[0].id;
+
+    server = http.createServer(app);
+    await new Promise((r) => server.listen(0, r));
+    port = server.address().port;
+  });
+
+  afterAll(async () => {
+    __setDbPool(null);
+    if (server) await new Promise((r) => server.close(r));
+    if (pool) await pool.end();
+  });
+
+  it('receives a journal event after journal_upsert', async () => {
+    const sseUrl = `http://127.0.0.1:${port}/events?room_id=${encodeURIComponent(roomId)}`;
+    const expectedHash = 'f'.repeat(64);
+
+    const got = await new Promise((resolve, reject) => {
+      const req = http.request(
+        sseUrl,
+        { method: 'GET', headers: { accept: 'text/event-stream' } },
+        (res) => {
+          res.setEncoding('utf8');
+          let buf = '';
+          let sawTimer = false;
+          const onData = async (chunk) => {
+            buf += chunk;
+            let idx;
+            while ((idx = buf.indexOf('\n\n')) !== -1) {
+              const frame = buf.slice(0, idx);
+              buf = buf.slice(idx + 2);
+              const evLine = frame.split('\n').find((l) => l.startsWith('event: '));
+              const dataLine = frame.split('\n').find((l) => l.startsWith('data: '));
+              if (!dataLine) continue;
+              const type = evLine ? evLine.slice(7).trim() : 'message';
+              const payload = JSON.parse(dataLine.slice(6));
+              if (!sawTimer && payload.t === 'timer') {
+                sawTimer = true;
+                try {
+                  await pool.query('select journal_upsert($1,$2,$3,$4::jsonb,$5::jsonb)', [
+                    roomId,
+                    0,
+                    expectedHash,
+                    JSON.stringify({}),
+                    JSON.stringify({ idx: 0 })
+                  ]);
+                } catch (e) {
+                  res.off('data', onData);
+                  res.destroy();
+                  return reject(e);
+                }
+              }
+              if (type === 'journal' && payload.t === 'journal' && payload.room_id === roomId) {
+                res.off('data', onData);
+                res.destroy();
+                return resolve(payload);
+              }
+            }
+          };
+          res.on('data', onData);
+          res.on('error', reject);
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(got.room_id).toBe(roomId);
+    expect(got.idx).toBe(0);
+    expect(got.hash).toBe(expectedHash);
+  }, 6000);
+});

--- a/web/app/room/[roomId]/page.jsx
+++ b/web/app/room/[roomId]/page.jsx
@@ -33,6 +33,7 @@ export default function RoomPage({ params }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [hasNewJournal, setHasNewJournal] = useState(false);
   const timerRef = useRef(null);
   const esRef = useRef(null);
   const lastNonceRef = useRef('');
@@ -71,6 +72,14 @@ export default function RoomPage({ params }) {
           void 0;
         }
       };
+      es.addEventListener('journal', (ev) => {
+        try {
+          const d = JSON.parse(ev.data);
+          if (d && d.t === 'journal' && d.room_id === roomId) setHasNewJournal(true);
+        } catch {
+          /* ignore */
+        }
+      });
       es.onerror = () => {
         try {
           es.close();
@@ -318,13 +327,14 @@ export default function RoomPage({ params }) {
             <div className="text-lg font-semibold">Transcript</div>
             <Badge variant="outline">{transcript.length} entries</Badge>
           </div>
-          <div className="text-sm">
+          <div className="text-sm flex items-center gap-3">
             <Link
               className="underline text-[color:var(--teal)]"
               href={`/journal/${encodeURIComponent(roomId)}`}
             >
               View journal history →
             </Link>
+            {hasNewJournal && <Badge variant="success">New checkpoint</Badge>}
           </div>
           {transcript.length === 0 ? (
             <p className="text-sm text-muted">No submissions yet.</p>


### PR DESCRIPTION
Summary\n- Add ENFORCE_AUTHOR_BINDING config flag and enforce in /rpc/provenance.verify.\n\nChanges\n- server/config/config-builder.js: reads ENFORCE_AUTHOR_BINDING.\n- server/rpc.js: when enabled and participant has no fingerprint, return 400 author_not_configured; mismatch path unchanged.\n- tests: new Vitest for enforcement enabled; baseline not_configured covered by existing tests.\n- docs/GettingStarted.md: add flag to Environment flags.\n\nTests\n- All suites green locally.\n\nNext\n- SSH pubkey verification path to round out M2.\n\nFixes #137