### PR TITLE
feat(web,server): strict SSE journal validation + lastSeen dedupe

### DIFF
--- a/db/rpc.sql
+++ b/db/rpc.sql
@@ -418,6 +418,9 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 BEGIN
+  IF p_round_idx < 0 THEN
+    RAISE EXCEPTION 'invalid_round_idx' USING ERRCODE = '22023';
+  END IF;
   INSERT INTO journals(room_id, round_idx, hash, signature, core)
   VALUES (p_room_id, p_round_idx, p_hash, COALESCE(p_signature, '{}'::jsonb), COALESCE(p_core, '{}'::jsonb))
   ON CONFLICT (room_id, round_idx)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -101,8 +101,8 @@ Endpoints (canonical realtime = SSE):
   - event: journal (emitted on DB NOTIFY from `journal_upsert`)
     - t: "journal"
     - room_id: string (uuid)
-    - idx: number (round index)
-    - hash: string (sha256 of the journal core)
+    - idx: integer ≥ 0 (round index)
+    - hash: string (64‑char lowercase hex, sha256 of the journal core)
     - Example frame:
 
   ```json

--- a/server/test/sse.db.journal.test.js
+++ b/server/test/sse.db.journal.test.js
@@ -94,7 +94,9 @@ suite('SSE /events emits journal on DB NOTIFY', () => {
     });
 
     expect(got.room_id).toBe(roomId);
+    expect(Number.isInteger(got.idx) && got.idx >= 0).toBe(true);
     expect(got.idx).toBe(0);
+    expect(/^[0-9a-f]{64}$/.test(got.hash)).toBe(true);
     expect(got.hash).toBe(expectedHash);
   }, 3000);
 });

--- a/web/lib/validateSse.js
+++ b/web/lib/validateSse.js
@@ -1,0 +1,30 @@
+export function isValidJournalEventPayload(roomId, obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  if (obj.t !== 'journal') return false;
+  if (String(obj.room_id) !== String(roomId)) return false;
+  if (!Number.isInteger(obj.idx) || obj.idx < 0) return false;
+  if (typeof obj.hash !== 'string' || !/^[0-9a-f]{64}$/.test(obj.hash)) return false;
+  return true;
+}
+
+const LS_PREFIX = 'db8.lastSeenJournalIdx:';
+
+export function getLastSeenJournalIdx(roomId) {
+  try {
+    const v = window.sessionStorage.getItem(LS_PREFIX + roomId);
+    const n = Number(v);
+    return Number.isInteger(n) && n >= 0 ? n : -1;
+  } catch {
+    return -1;
+  }
+}
+
+export function setLastSeenJournalIdx(roomId, idx) {
+  try {
+    if (Number.isInteger(idx) && idx >= 0) {
+      window.sessionStorage.setItem(LS_PREFIX + roomId, String(idx));
+    }
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
Summary\n- Web: add SSE journal validator + lastSeen index dedupe via sessionStorage; clear on journal link click.\n- Server: assert non-negative round index in journal_upsert.\n- Tests: add SSE journal payload shape checks.\n- Docs: clarify event: journal payload (idx integer ≥ 0, hash 64-hex).\n\nChanges\n- web/lib/validateSse.js (new); web/app/room/[roomId]/page.jsx updates.\n- db/rpc.sql journal_upsert guard.\n- server/test/sse.db.journal.test.js shape assertions.\n- docs/GettingStarted.md journaling frame notes.\n\nTests\n- All suites green locally (docker-backed Postgres).\n\nNext\n- SSH pubkey verification path to close M2.\n\nFixes #139