### PR TITLE
test(server): make the lifecycle round transition re-runnable

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/james/git/db8/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/james/git/db8/node_modules

--- a/server/test/lifecycle.test.js
+++ b/server/test/lifecycle.test.js
@@ -25,19 +25,27 @@ describe('Room Lifecycle (M4)', () => {
     const roundId = '77777777-0000-0000-0000-000000000002';
     const participantId = '77777777-0000-0000-0000-000000000003';
 
-    await pool.query(
-      'insert into rooms(id, title, status) values ($1, $2, $3) on conflict (id) do update set status = excluded.status',
-      [roomId, 'Lifecycle Room Unique', 'active']
-    );
+    // Seed from scratch. ON CONFLICT DO NOTHING left the previous run's terminal
+    // state in place — the round stayed 'final' and the room stayed 'closed' —
+    // so a re-run asserted against stale rows instead of exercising the
+    // transition, and the vote insert below collided on its fixed client_nonce.
+    // Deleting the room cascades to rounds, participants and votes.
+    await pool.query('delete from rooms where id = $1', [roomId]);
+    await pool.query('insert into rooms(id, title, status) values ($1, $2, $3)', [
+      roomId,
+      'Lifecycle Room Unique',
+      'active'
+    ]);
     // Round is published and vote window closed
     await pool.query(
-      "insert into rounds(id, room_id, idx, phase, continue_vote_close_unix) values ($1, $2, 0, 'published', 100) on conflict (id) do nothing",
+      "insert into rounds(id, room_id, idx, phase, continue_vote_close_unix) values ($1, $2, 0, 'published', 100)",
       [roundId, roomId]
     );
-    await pool.query(
-      'insert into participants(id, room_id, anon_name) values ($1, $2, $3) on conflict (id) do nothing',
-      [participantId, roomId, 'voter_unique_1']
-    );
+    await pool.query('insert into participants(id, room_id, anon_name) values ($1, $2, $3)', [
+      participantId,
+      roomId,
+      'voter_unique_1'
+    ]);
 
     // Tally is No (or equal), so it should transition to final
     await pool.query(


### PR DESCRIPTION
## Summary

`lifecycle.test.js` seeded with `ON CONFLICT DO NOTHING` and never cleaned up, so a second run against the same database hit two problems — one loud, one silent.

The loud one: the continue vote is inserted with a fixed `client_nonce`, so a re-run collided on `votes_round_id_voter_id_kind_client_nonce_key` and failed outright.

The quiet one matters more. The round row survived from the previous run still in phase `final`, and the room still `closed`. Both assertions therefore passed against terminal state left behind by the earlier run, **without `round_open_next()` having been exercised at all**.

## Changes

- `server/test/lifecycle.test.js` — delete the room first, then seed unconditionally. The delete cascades to rounds, participants and votes, so every run starts from a known `published` round with exactly one `end` vote and genuinely drives the transition.

## Tests

- Three consecutive runs against the same database, all green.
- Full suite: 104 passed.

## Next

Sibling PRs: #172 (audit FK — a production bug, not just test state) and `fix/research-test-isolation`. With all three, the suite is idempotent across repeated runs.