### PR TITLE
test(server): make research cache and quota tests re-runnable

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/james/git/db8/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/james/git/db8/node_modules

--- a/server/test/research.test.js
+++ b/server/test/research.test.js
@@ -10,18 +10,31 @@ describe('Research Tools & Cache (M6)', () => {
     process.env.DATABASE_URL ||
     'postgresql://postgres:test@localhost:54329/db8_test';
 
-  beforeAll(async () => {
-    pool = new pg.Pool({ connectionString: dbUrl });
-    __setDbPool(pool);
-  });
-
-  afterAll(async () => {
-    await pool.end();
-  });
-
   const roomId = '66660000-0000-0000-0000-000000000001';
   const roundId = '66660000-0000-0000-0000-000000000002';
   const participantId = '66660000-0000-0000-0000-000000000003';
+  const limitedRoom = '66660000-0000-0000-0000-000000000010';
+  const limitedRound = '66660000-0000-0000-0000-000000000011';
+  const urls = ['https://example.com/evidence', 'https://a.com', 'https://b.com'];
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString: dbUrl });
+    __setDbPool(pool);
+    // research_cache is global (keyed by url_hash) and research_usage accumulates
+    // per round, so neither resets between runs. Left alone, the first fetch below
+    // reports cached=true on a second run, and the quota round starts already spent
+    // — which made the quota test pass vacuously rather than by exercising the
+    // limit. Clear both before the suite, not between tests: the cache-retrieval
+    // test deliberately reads what the first test wrote.
+    await pool.query('delete from research_cache where url = any($1)', [urls]);
+    await pool.query('delete from research_usage where room_id = any($1)', [[roomId, limitedRoom]]);
+  });
+
+  afterAll(async () => {
+    await pool.query('delete from research_cache where url = any($1)', [urls]);
+    await pool.query('delete from research_usage where room_id = any($1)', [[roomId, limitedRoom]]);
+    await pool.end();
+  });
 
   it('POST /rpc/research.fetch should snapshot content and cache it', async () => {
     await pool.query(
@@ -59,9 +72,6 @@ describe('Research Tools & Cache (M6)', () => {
   });
 
   it('POST /rpc/research.fetch should enforce per-round quotas', async () => {
-    const limitedRoom = '66660000-0000-0000-0000-000000000010';
-    const limitedRound = '66660000-0000-0000-0000-000000000011';
-
     await pool.query(
       'insert into rooms(id, title, config) values ($1, $2, $3) on conflict (id) do nothing',
       [limitedRoom, 'Quota Room', JSON.stringify({ max_fetches_per_round: 1 })]
@@ -75,15 +85,16 @@ describe('Research Tools & Cache (M6)', () => {
       [participantId, limitedRoom, 'researcher_quota']
     );
 
-    // First fetch
-    await supertest(app)
-      .post('/rpc/research.fetch')
-      .send({
-        room_id: limitedRoom,
-        round_id: limitedRound,
-        participant_id: participantId,
-        url: 'https://a.com'
-      });
+    // First fetch must succeed, or the 429 below proves nothing: a round whose
+    // quota was already spent by an earlier run would reject both calls and the
+    // assertion would pass without the limit ever being exercised.
+    const first = await supertest(app).post('/rpc/research.fetch').send({
+      room_id: limitedRoom,
+      round_id: limitedRound,
+      participant_id: participantId,
+      url: 'https://a.com'
+    });
+    expect(first.status).toBe(200);
 
     // Second fetch (new URL) should fail
     const res = await supertest(app).post('/rpc/research.fetch').send({


### PR DESCRIPTION
## Summary

Neither piece of state `research.test.js` depends on resets between runs.

`research_cache` is global, keyed by `url_hash`, so on a second run the first fetch returned `cached=true` and failed its assertion outright.

`research_usage` was the quieter problem. It accumulates per `(room_id, round_id)`, so the quota round started already spent and **both** fetches were rejected — the test still saw its 429 and passed, without the limit ever being exercised. A vacuous pass is worse than the visible failure beside it, because nothing reports it.

## Changes

- `server/test/research.test.js`
  - Clear `research_cache` and `research_usage` for this file's three URLs and two rooms in `beforeAll`, and again in `afterAll`. Clearing is per-suite rather than per-test on purpose: the cache-retrieval case reads what the first test wrote, and that coupling is intended.
  - Assert the quota test's first fetch returns 200, so the round is known to have had quota when the 429 is asserted. That assertion is what stops the vacuous pass from returning.
  - Hoist the quota room/round ids to suite scope so cleanup can reach them.

## Tests

- Three consecutive runs against the same database, all green.
- Full suite: 104 passed.

## Next

Sibling PRs: #172 (audit FK — a production bug) and #173 (lifecycle). With all three, the suite is idempotent across repeated runs.