### PR TITLE
fix(journal): make persistent signing key creation atomic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ pnpm-debug.log*
 .env.*.local
 
 # db8 signing keys (local-only; never commit)
-.db8_signing_key
-.db8_signing_key.pub
+# The wildcard also covers the .tmp.<pid>.<rand> staging files used to publish
+# the pair atomically; those are unlinked on success but can survive a crash.
+.db8_signing_key*
 
 # Next.js / Frontend
 .next/

--- a/server/test/signing.keys.test.js
+++ b/server/test/signing.keys.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile as _execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getPersistentSigningKeys } from '../utils.js';
+
+const execFile = promisify(_execFile);
+
+// The journal signer persists an Ed25519 pair to disk so restarts keep signing
+// with the same identity. Getting that wrong is not an availability problem, it is
+// a provenance problem: a mismatched or silently replaced pair makes every
+// journal signature unverifiable, permanently, with no error at signing time.
+describe('persistent signing keys', () => {
+  let dir;
+  let privPath;
+  let pubPath;
+  const saved = {};
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'db8-keys-'));
+    privPath = path.join(dir, 'key');
+    pubPath = path.join(dir, 'key.pub');
+    saved.priv = process.env.SIGNING_PRIVATE_KEY;
+    saved.pub = process.env.SIGNING_PUBLIC_KEY;
+    delete process.env.SIGNING_PRIVATE_KEY;
+    delete process.env.SIGNING_PUBLIC_KEY;
+    process.env.SIGNING_PRIVATE_KEY_PATH = privPath;
+    process.env.SIGNING_PUBLIC_KEY_PATH = pubPath;
+  });
+
+  afterEach(() => {
+    delete process.env.SIGNING_PRIVATE_KEY_PATH;
+    delete process.env.SIGNING_PUBLIC_KEY_PATH;
+    if (saved.priv !== undefined) process.env.SIGNING_PRIVATE_KEY = saved.priv;
+    if (saved.pub !== undefined) process.env.SIGNING_PUBLIC_KEY = saved.pub;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function pairMatches(privPem, pubPem) {
+    const derived = crypto
+      .createPublicKey(crypto.createPrivateKey(privPem))
+      .export({ format: 'der', type: 'spki' })
+      .toString('base64');
+    const given = crypto
+      .createPublicKey(pubPem)
+      .export({ format: 'der', type: 'spki' })
+      .toString('base64');
+    return derived === given;
+  }
+
+  it('generates a matching pair when none exists', () => {
+    const keys = getPersistentSigningKeys();
+    expect(pairMatches(keys.privateKeyPem, keys.publicKeyPem)).toBe(true);
+    expect(fs.existsSync(privPath)).toBe(true);
+    expect(fs.existsSync(pubPath)).toBe(true);
+  });
+
+  it('writes the private key with owner-only permissions', () => {
+    getPersistentSigningKeys();
+    expect(fs.statSync(privPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('returns what is on disk on a second call rather than regenerating', () => {
+    const first = getPersistentSigningKeys();
+    const second = getPersistentSigningKeys();
+    expect(second.privateKeyPem).toBe(first.privateKeyPem);
+    expect(second.publicKeyPem).toBe(first.publicKeyPem);
+  });
+
+  it('returns the persisted pair, not an in-memory one, when both exist', () => {
+    getPersistentSigningKeys();
+    const keys = getPersistentSigningKeys();
+    expect(keys.privateKeyPem).toBe(fs.readFileSync(privPath, 'utf8'));
+    expect(keys.publicKeyPem).toBe(fs.readFileSync(pubPath, 'utf8'));
+  });
+
+  // The regression this file exists for. Concurrent starters all saw no key,
+  // each generated its own pair, and each wrote private and public in two
+  // separate non-atomic steps — so the surviving files could come from
+  // different pairs, and every process kept using its own in-memory pair
+  // regardless of what landed on disk.
+  it('converges on one pair when many processes start at once', async () => {
+    const script = `
+      import { getPersistentSigningKeys } from ${JSON.stringify(path.resolve('server/utils.js'))};
+      const k = getPersistentSigningKeys();
+      process.stdout.write(k.publicKeyPem);
+    `;
+    const runs = Array.from({ length: 12 }, () =>
+      execFile(process.execPath, ['--input-type=module', '-e', script], {
+        env: {
+          ...process.env,
+          SIGNING_PRIVATE_KEY_PATH: privPath,
+          SIGNING_PUBLIC_KEY_PATH: pubPath
+        }
+      })
+    );
+    const results = await Promise.all(runs);
+    const reported = results.map((r) => r.stdout.trim());
+
+    // Every process must agree.
+    expect(new Set(reported).size).toBe(1);
+
+    // And what they agreed on must be what is actually persisted, and must
+    // genuinely correspond to the persisted private key.
+    const diskPriv = fs.readFileSync(privPath, 'utf8');
+    const diskPub = fs.readFileSync(pubPath, 'utf8');
+    expect(reported[0]).toBe(diskPub.trim());
+    expect(pairMatches(diskPriv, diskPub)).toBe(true);
+  });
+
+  it('rebuilds a missing public half instead of replacing the private key', () => {
+    const { privateKey } = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+    });
+    fs.writeFileSync(privPath, privateKey, { mode: 0o600 });
+
+    const keys = getPersistentSigningKeys();
+    // The private key is the source of truth and must survive: regenerating the
+    // pair here would strand every journal it had already signed.
+    expect(fs.readFileSync(privPath, 'utf8')).toBe(privateKey);
+    expect(keys.privateKeyPem).toBe(privateKey);
+    // The public half is derivable, so recovery is exact rather than a guess.
+    expect(pairMatches(keys.privateKeyPem, keys.publicKeyPem)).toBe(true);
+    expect(fs.existsSync(pubPath)).toBe(true);
+  });
+
+  it('refuses when only the public half is present', () => {
+    const { publicKey } = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+    });
+    fs.writeFileSync(pubPath, publicKey);
+
+    // A private key cannot be recovered from a public one. Generating a fresh
+    // pair here would silently invalidate everything ever signed under the
+    // published key, which is the failure mode worth being loud about.
+    expect(() => getPersistentSigningKeys()).toThrow(/private/i);
+  });
+
+  it('rejects a persisted pair whose halves do not correspond', () => {
+    const a = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+    });
+    const b = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+    });
+    fs.writeFileSync(privPath, a.privateKey, { mode: 0o600 });
+    fs.writeFileSync(pubPath, b.publicKey);
+
+    // Signing with a and publishing b produces signatures nothing can verify.
+    // Failing loudly at startup beats discovering it in an audit.
+    expect(() => getPersistentSigningKeys()).toThrow(/match/i);
+  });
+
+  it('still prefers explicitly configured environment keys', () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+    });
+    process.env.SIGNING_PRIVATE_KEY = privateKey;
+    process.env.SIGNING_PUBLIC_KEY = publicKey;
+    const keys = getPersistentSigningKeys();
+    expect(keys.privateKeyPem).toBe(privateKey);
+    expect(fs.existsSync(privPath)).toBe(false);
+  });
+});

--- a/server/utils.js
+++ b/server/utils.js
@@ -35,6 +35,21 @@ export const log = {
     console.error(JSON.stringify({ level: 'error', t: Date.now(), msg, ...details }))
 };
 
+// Ed25519 public keys are derivable from the private key, so the private key is
+// the single source of truth and the .pub file is only a published convenience.
+// Correctness never depends on reading it, which is what makes concurrent
+// startup safe.
+function derivePublicPem(privateKeyPem) {
+  return crypto
+    .createPublicKey(crypto.createPrivateKey(privateKeyPem))
+    .export({ type: 'spki', format: 'pem' })
+    .toString();
+}
+
+function spki(pem) {
+  return crypto.createPublicKey(pem).export({ type: 'spki', format: 'der' }).toString('base64');
+}
+
 // M7: Ensure signing keys exist
 export function getPersistentSigningKeys() {
   const privPath = process.env.SIGNING_PRIVATE_KEY_PATH || './.db8_signing_key';
@@ -47,34 +62,106 @@ export function getPersistentSigningKeys() {
     };
   }
 
-  try {
-    if (fs.existsSync(privPath) && fs.existsSync(pubPath)) {
-      return {
-        privateKeyPem: fs.readFileSync(privPath, 'utf8'),
-        publicKeyPem: fs.readFileSync(pubPath, 'utf8')
-      };
+  // Publish the public half atomically. Every process derives identical bytes
+  // from the same private key, so clobbering via rename is safe — and rename
+  // means a concurrent reader sees the old file or the new one, never a
+  // half-written one.
+  const publishPublic = (pem) => {
+    const tmp = `${pubPath}.tmp.${process.pid}.${crypto.randomBytes(6).toString('hex')}`;
+    try {
+      fs.writeFileSync(tmp, pem, { mode: 0o644 });
+      fs.renameSync(tmp, pubPath);
+    } catch (e) {
+      log.error('failed to write public key', { error: e.message });
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // Best effort; a stray temp public key is inert.
+      }
     }
-  } catch (e) {
-    log.error('failed to read keys', { error: e.message });
+  };
+
+  // Adopt an existing private key. Never regenerate over one: every journal it
+  // has already signed would become unverifiable, silently.
+  const adopt = () => {
+    const privateKeyPem = fs.readFileSync(privPath, 'utf8');
+    const derivedPem = derivePublicPem(privateKeyPem);
+
+    if (fs.existsSync(pubPath)) {
+      // Distinguish a corrupt public file from a genuinely wrong one. A file we
+      // cannot decode carries no information, so republishing it loses nothing.
+      // A file that decodes to a different key is a real conflict and needs a
+      // human, because it means signatures are being published unverifiable.
+      let onDisk = null;
+      let raw = null;
+      try {
+        raw = fs.readFileSync(pubPath, 'utf8');
+        onDisk = spki(raw);
+      } catch {
+        onDisk = null;
+      }
+
+      if (onDisk !== null) {
+        if (onDisk !== spki(derivedPem)) {
+          throw new Error(
+            `signing keys do not match: ${pubPath} is not the public half of ${privPath}. ` +
+              'Signatures made with this private key cannot be verified against the published ' +
+              'public key. Remove the stale public file to republish it, or restore the correct pair.'
+          );
+        }
+        return { privateKeyPem, publicKeyPem: raw };
+      }
+    }
+
+    // Missing or unreadable: rebuild from the private key. Exact, not a guess.
+    publishPublic(derivedPem);
+    return { privateKeyPem, publicKeyPem: derivedPem };
+  };
+
+  if (fs.existsSync(privPath)) return adopt();
+
+  if (fs.existsSync(pubPath)) {
+    throw new Error(
+      `signing key missing: ${pubPath} exists but ${privPath} does not. A private key cannot ` +
+        'be recovered from a public one; generating a fresh pair here would invalidate ' +
+        'everything already signed under the published key. Restore the private key, or ' +
+        'remove the public file to deliberately start a new identity.'
+    );
   }
 
-  // Generate and save
   log.warn('no signing keys found, generating new persistent pair');
-  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
+  const { privateKey } = crypto.generateKeyPairSync('ed25519', {
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   });
 
+  // Create the key atomically *with its contents already in place*. Opening the
+  // destination with 'wx' is not enough: that creates an empty file first, so a
+  // concurrent starter can observe the path existing and read a truncated key.
+  // Writing to a private temp file and hard-linking it into position makes the
+  // key appear complete or not at all, and link() fails rather than clobbering,
+  // so exactly one starter wins and the rest adopt its key.
+  const tmpPath = `${privPath}.tmp.${process.pid}.${crypto.randomBytes(6).toString('hex')}`;
   try {
-    const fd = fs.openSync(privPath, 'w', 0o600);
-    fs.writeFileSync(fd, privateKey);
-    fs.closeSync(fd);
-    fs.writeFileSync(pubPath, publicKey);
-  } catch (e) {
-    log.error('failed to save keys', { error: e.message });
+    fs.writeFileSync(tmpPath, privateKey, { mode: 0o600 });
+    try {
+      fs.linkSync(tmpPath, privPath);
+    } catch (e) {
+      if (e.code !== 'EEXIST') {
+        throw new Error(`failed to persist signing key at ${privPath}: ${e.message}`, { cause: e });
+      }
+      // Lost the race; the winner's key is already in place and is adopted below.
+    }
+  } finally {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Best effort: a leftover temp key is inert, and failing here would mask
+      // whatever the caller actually needs to know.
+    }
   }
 
-  return { privateKeyPem: privateKey, publicKeyPem: publicKey };
+  return adopt();
 }
 
 export function sha256Hex(s) {


### PR DESCRIPTION
## Summary

`getPersistentSigningKeys` checked for the key files and, if absent, generated a pair and wrote the private and public halves in **two separate non-exclusive steps**. Concurrent starters each generated their own pair and raced. Two failure modes followed, both silent.

The surviving files could come from **different pairs** — private from one starter, public from another — leaving a persisted keypair whose halves do not correspond. Every journal signed afterwards is unverifiable against the published key, with no error at signing time. For a system whose thesis is cryptographic provenance, that is the failure worth caring about most.

Separately, each process returned the pair *it* had generated rather than the one that reached disk, so even the winner's peers signed with keys nobody could look up.

This was observed, not theorised. A fresh checkout running the suite persisted a mismatched pair on its first run, and every journal test failed from then on (`pub matches priv: false`).

## Changes

`server/utils.js` — treat the private key as the single source of truth, since an Ed25519 public key is derivable from it:

- Create the private key by writing a temp file and **hard-linking** it into place. `link()` fails rather than clobbering, so exactly one starter wins.
- Losers adopt the winner's key and derive the public half, so correctness never depends on reading the second file.
- Publish the public half via temp file + `rename`, so a concurrent reader sees old bytes or new, never a partial write.
- Adopt an existing private key rather than regenerating over it. A missing public half is rebuilt by derivation; an unreadable one is republished.
- Fail loudly when a decodable public file disagrees with the private key, or when only a public half is present — neither is recoverable silently.

`.gitignore` — widen to `.db8_signing_key*` so crash-stranded temp staging files can never be committed.

## Tests

`server/test/signing.keys.test.js`, 9 cases. Run against the **unmodified original implementation**, 4 fail:

- 12 concurrent processes produce **4 distinct keys** (expected 1)
- the private key is **overwritten** when the public half is missing
- a public-only state silently generates a fresh identity instead of refusing
- a mismatched persisted pair is returned instead of refusing

All 9 pass on this branch.

## Measured behaviour

Separate harness, 12 concurrent processes per iteration, each checking that every process agrees *and* that the persisted pair is internally consistent:

| Implementation | Result |
| --- | --- |
| original | **52/60 fail** (87%) |
| this branch | 60/60 pass (c12), 50/50 pass (c48) |

**Correcting an earlier version of this description**, which claimed `'wx'` alone was measurably insufficient. That was wrong. Both intermittent failures seen while developing this were the *public*-file race, not the private one. Under natural load `'wx'` and `link()` are indistinguishable — both 60/60 at c12 and 50/50 at c48.

The private-key window is nonetheless real, and `link()` is what closes it. Demonstrated by widening it with an identical 30 ms delay inserted into each variant:

| Variant (30 ms delay between staging and publish) | Result |
| --- | --- |
| `'wx'` — creates the file empty, then writes | **0/25 pass**; readers hit a truncated key |
| `link()` — file appears complete or not at all | 25/25 pass |

So `link()` is justified on correctness under adverse timing (slow or contended filesystems, loaded hosts), not because it was measured failing here. It costs nothing, and the failure it prevents is silent and permanent.

## Next

Sibling PRs #172, #173, #174 fix the test-idempotency failures. Those three plus this one are independent and can land in any order.