### PR TITLE
fix(journal): 404 a missing round instead of answering with a different one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ---
-lastUpdated: 2025-10-04
+lastUpdated: 2026-08-09
 ---
 
 # Changelog
+
+## 2026-08-09 — `GET /journal` indexed lookups (breaking)
+
+- `GET /journal?room_id&idx=<n>` now returns **404** when the room has no such round, in both the database and in-memory paths. It previously returned **200** carrying the room's _latest_ journal, so a request for round 999 was answered with round 0 under `ok: true`.
+- A non-integer or negative `idx` now returns **400** `invalid_idx`. It was previously coerced (`Number('abc')` → `NaN`) and silently fell through to the latest journal.
+- The not-found response carries a 404 status rather than a 200 with `ok: false`; callers branching on status code read the old form as success.
+
+Callers that treated any 2xx as "journal found" must now handle 404, and callers that passed unvalidated `idx` values must handle 400.
 
 ## 2025-10-04 — PR #118 merged (M2 foundations)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ lastUpdated: 2026-08-09
 - A non-integer or negative `idx` now returns **400** `invalid_idx`. It was previously coerced (`Number('abc')` → `NaN`) and silently fell through to the latest journal.
 - The not-found response carries a 404 status rather than a 200 with `ok: false`; callers branching on status code read the old form as success.
 
-Callers that treated any 2xx as "journal found" must now handle 404, and callers that passed unvalidated `idx` values must handle 400.
+Callers that treated any 2xx as "journal found" must now handle 404, and callers that passed unchecked `idx` values must handle 400.
 
 ## 2025-10-04 — PR #118 merged (M2 foundations)
 

--- a/server/routes/journal.js
+++ b/server/routes/journal.js
@@ -16,12 +16,23 @@ export function createJournalRouter({ db, buildLatestJournal }) {
               : 'SELECT * FROM journals WHERE room_id = $1 ORDER BY round_idx DESC LIMIT 1';
           const r = await db.query(q, idx !== undefined ? [roomId, Number(idx)] : [roomId]);
           if (r.rows[0]) return res.json({ ok: true, journal: r.rows[0] });
+          // A specific round was asked for and the database does not have it.
+          // Do not fall through to the in-memory builder below: that answers a
+          // different question than the caller asked, handing back the latest
+          // round to someone who requested round 999. Since RoomService
+          // auto-creates unknown rooms in memory, the fallback would also
+          // synthesize a journal for a room that has never existed.
+          if (idx !== undefined) {
+            return res.status(404).json({ ok: false, error: 'journal_not_found' });
+          }
         } catch (dbErr) {
           console.error('[router] GET /journal DB error, falling back:', dbErr.message);
         }
       }
       const latest = await buildLatestJournal(roomId);
-      if (!latest) return res.json({ ok: false, error: 'journal_not_found' });
+      // 404, not a 200 carrying ok:false — callers that branch on status code
+      // otherwise read "no journal" as success.
+      if (!latest) return res.status(404).json({ ok: false, error: 'journal_not_found' });
       return res.json({ ok: true, journal: latest });
     } catch (err) {
       console.error('[router] GET /journal error:', err);

--- a/server/routes/journal.js
+++ b/server/routes/journal.js
@@ -6,33 +6,51 @@ export function createJournalRouter({ db, buildLatestJournal }) {
   // /journal
   router.get('/journal', async (req, res) => {
     const roomId = String(req.query.room_id || 'local');
-    const idx = req.query.idx;
+    const rawIdx = req.query.idx;
+    const hasIdx = rawIdx !== undefined;
+
+    // Validate at the edge rather than inside the database branch. Number('abc')
+    // is NaN and Number('-1') is negative; both previously reached the query
+    // unchecked and, finding nothing, fell through to the in-memory builder.
+    let idx;
+    if (hasIdx) {
+      idx = Number(rawIdx);
+      if (!Number.isInteger(idx) || idx < 0) {
+        return res.status(400).json({ ok: false, error: 'invalid_idx' });
+      }
+    }
+
     try {
       if (db) {
+        let queried = false;
         try {
-          const q =
-            idx !== undefined
-              ? 'SELECT * FROM journals WHERE room_id = $1 AND round_idx = $2'
-              : 'SELECT * FROM journals WHERE room_id = $1 ORDER BY round_idx DESC LIMIT 1';
-          const r = await db.query(q, idx !== undefined ? [roomId, Number(idx)] : [roomId]);
+          const q = hasIdx
+            ? 'SELECT * FROM journals WHERE room_id = $1 AND round_idx = $2'
+            : 'SELECT * FROM journals WHERE room_id = $1 ORDER BY round_idx DESC LIMIT 1';
+          const r = await db.query(q, hasIdx ? [roomId, idx] : [roomId]);
           if (r.rows[0]) return res.json({ ok: true, journal: r.rows[0] });
-          // A specific round was asked for and the database does not have it.
-          // Do not fall through to the in-memory builder below: that answers a
-          // different question than the caller asked, handing back the latest
-          // round to someone who requested round 999. Since RoomService
-          // auto-creates unknown rooms in memory, the fallback would also
-          // synthesize a journal for a room that has never existed.
-          if (idx !== undefined) {
-            return res.status(404).json({ ok: false, error: 'journal_not_found' });
-          }
+          queried = true;
         } catch (dbErr) {
           console.error('[router] GET /journal DB error, falling back:', dbErr.message);
         }
+        // The database answered and holds no such round. That is authoritative,
+        // so do not consult the in-memory builder: it would answer a different
+        // question than the caller asked.
+        if (queried && hasIdx) {
+          return res.status(404).json({ ok: false, error: 'journal_not_found' });
+        }
       }
+
       const latest = await buildLatestJournal(roomId);
       // 404, not a 200 carrying ok:false — callers that branch on status code
       // otherwise read "no journal" as success.
       if (!latest) return res.status(404).json({ ok: false, error: 'journal_not_found' });
+      // buildLatestJournal only ever produces the most recent round, and
+      // RoomService auto-creates unknown rooms, so without this an indexed
+      // request in memory mode is answered with a synthesized round 0.
+      if (hasIdx && Number(latest?.core?.idx) !== idx) {
+        return res.status(404).json({ ok: false, error: 'journal_not_found' });
+      }
       return res.json({ ok: true, journal: latest });
     } catch (err) {
       console.error('[router] GET /journal error:', err);

--- a/server/test/journal.idx.memory.test.js
+++ b/server/test/journal.idx.memory.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import app, { __setDbPool } from '../rpc.js';
+
+// Regression for the memory-mode half of the indexed-journal bug.
+//
+// The 404 guard was placed inside the `if (db)` branch, so it only protected
+// the database path. With no pool attached — a supported mode, and the one the
+// bulk of this suite runs in — a request for a specific round still fell
+// through to buildLatestJournal(), which ignores idx entirely. Asking for round
+// 999 of a room that never existed returned 200 and a synthesized round 0,
+// because RoomService auto-creates unknown rooms in memory.
+//
+// Deliberately not gated behind DB8_TEST_PG: the defect lives in the no-database
+// path, so the test must run where there is no database.
+describe('GET /journal?idx — memory mode', () => {
+  let server;
+  let url;
+
+  beforeAll(async () => {
+    __setDbPool(null);
+    server = http.createServer(app);
+    await new Promise((resolve) => server.listen(0, resolve));
+    url = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it('404s for a round the room does not have', async () => {
+    const room = crypto.randomUUID();
+    const res = await fetch(`${url}/journal?room_id=${encodeURIComponent(room)}&idx=999`);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not answer an indexed request with a different round', async () => {
+    const room = crypto.randomUUID();
+    const res = await fetch(`${url}/journal?room_id=${encodeURIComponent(room)}&idx=999`);
+    const body = await res.json().catch(() => ({}));
+    // The failure this guards against is subtler than the status code: round 0
+    // was returned under ok:true for a request that named round 999.
+    expect(body?.journal?.core?.idx).not.toBe(0);
+    expect(body?.ok).not.toBe(true);
+  });
+
+  it('400s a non-numeric idx rather than coercing it to NaN', async () => {
+    const room = crypto.randomUUID();
+    const res = await fetch(`${url}/journal?room_id=${encodeURIComponent(room)}&idx=abc`);
+    expect(res.status).toBe(400);
+  });
+
+  it('400s a negative idx', async () => {
+    const room = crypto.randomUUID();
+    const res = await fetch(`${url}/journal?room_id=${encodeURIComponent(room)}&idx=-1`);
+    expect(res.status).toBe(400);
+  });
+
+  it('still serves the latest journal when no idx is given', async () => {
+    const room = crypto.randomUUID();
+    const res = await fetch(`${url}/journal?room_id=${encodeURIComponent(room)}`);
+    expect(res.status).toBe(200);
+    expect((await res.json())?.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`GET /journal?room_id=…&idx=999` returned **200 with the room's latest journal**.

Two faults compounded:

1. When a specific round was requested and the database had no row for it, the handler fell through to `buildLatestJournal()`, **which ignores `idx` entirely** — so a caller asking for round 999 was handed round 0 and told `ok: true`. Because `RoomService` auto-creates unknown rooms in memory, the fallback also synthesized a journal for a room that had never existed.
2. The not-found branch used `res.json()` with no status, so even a genuine miss returned **200 carrying `ok: false`** — which any caller branching on status code reads as success.

Returning the wrong round with a success status is the worse half. For a journal endpoint whose purpose is verifiable provenance, silently substituting a different round is a correctness failure, not a cosmetic one.

## Changes

`server/routes/journal.js` — return 404 for a requested index the database does not have, without consulting the in-memory builder, and give the remaining not-found path its status.

## How this shipped

It regressed when `rpc.js` was split into `routes/`, and `server/test/journal.byidx.test.js` has been catching it since M7 was written — **`db-tests` ran on that branch three times in December and failed every time.**

The workflow did not run on #176, the PR that merged M6/M7, so the known failure reached `main` unnoticed. Attribution verified by bisect:

| Ref | Result |
| --- | --- |
| `8ca1dc2` (pre-#176, M5) | **2 passed** |
| `main` today (post-#176) | **1 failed / 1 passed** |

## Tests

- `server/test/journal.byidx.test.js`: **2/2 pass** (was 1 failed / 1 passed).
- Full suite: **113 passed**, 0 failed.
- `eslint` clean.

Note: the failing test is gated behind `DB8_TEST_PG`, so neither `ci.yml` nor `build-test.yml` runs it — which is the actual reason this was invisible. Setting that variable in the workflows belongs with the other gate work in #177 rather than here.

Separately, running the full gated set surfaces pre-existing `deadlock detected` failures from concurrent `TRUNCATE` in `rpc.db.postgres.test.js:59` — those tests aren't parallel-safe. Untouched here; worth its own issue.

@codex please review.