### PR TITLE
test(db): scope DB-gated fixtures so they can run in parallel

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,11 +70,11 @@ jobs:
         run: npm run test:inner
 
       # Idempotency plus the DB-gated suites — see the matching step in ci.yml
-      # for why both live in one pass and why parallelism is disabled here.
+      # for why both gates live in one pass.
       - name: Run tests (pass 2 — same database, DB-gated, idempotency gate)
         env:
           DATABASE_URL: postgresql://postgres:test@localhost:5432/db8_test
           DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/db8_test
           DB8_TEST_PG: '1'
           CI: true
-        run: npx vitest run --no-file-parallelism
+        run: npm run test:inner

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,8 +69,7 @@ jobs:
           DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/db8_test
           DB8_TEST_PG: '1'
           CI: true
-        # Serialised — see ci.yml.
-        run: npx vitest run --no-file-parallelism
+        run: npm run test:inner
 
       # Idempotency plus the DB-gated suites — see the matching step in ci.yml
       # for why both gates live in one pass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
           DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
           DB8_TEST_PG: '1'
-        # Serialised for the same reason as pass 2 on this branch: the gated
-        # suites re-apply the schema and TRUNCATE shared tables, so running them
-        # alongside the rest deadlocks. Both flags come out once the fixtures
-        # are self-scoped.
-        run: npx vitest run --no-file-parallelism
+        run: npm test
 
       # Pass 2 carries two gates at once.
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,14 @@ jobs:
       #
       # DB8_TEST_PG unlocks six DB-gated suites that no workflow ran, which is
       # how a journal endpoint that answered idx=999 with the latest round
-      # reached main. Those suites TRUNCATE shared tables, so they deadlock
-      # against concurrent writers; --no-file-parallelism serialises them. Fix
-      # the fixtures to be self-scoped and this flag can go.
+      # reached main. They run in parallel with everything else: their
+      # fixtures are self-scoped now.
       - name: Tests (pass 2 — same database, DB-gated, idempotency gate)
         env:
           DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
           DB8_TEST_DATABASE_URL: postgresql://postgres:test@localhost:54329/db8_test
           DB8_TEST_PG: '1'
-        run: npx vitest run --no-file-parallelism
+        run: npm run test:inner
 
       - name: Tests (Postgres RPC integration)
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.54.0",
         "canonicalize": "2.1.0",
         "express": "^5.1.0",
         "zod": "^3.25.76"
@@ -27,6 +26,7 @@
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-unicorn": "^61.0.2",
+        "js-yaml": "^4.1.0",
         "lint-staged": "^16.2.3",
         "markdown-link-check": "^3.12.2",
         "markdownlint": "^0.33.0",
@@ -639,6 +639,74 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.10",
       "cpu": [
@@ -649,6 +717,363 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -5128,6 +5553,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-security": "^3.0.1",
     "eslint-plugin-unicorn": "^61.0.2",
+    "js-yaml": "^4.1.0",
     "lint-staged": "^16.2.3",
     "markdown-link-check": "^3.12.2",
     "markdownlint": "^0.33.0",

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -56,5 +56,5 @@ docker compose -f "$COMPOSE_FILE" run $DOCKER_TTY --rm tests bash -lc '
   echo "── pass 1 of 2: fresh database ──"
   npm run test:inner
   echo "── pass 2 of 2: same database, DB-gated (idempotency gate) ──"
-  DB8_TEST_PG=1 npx vitest run --no-file-parallelism
+  DB8_TEST_PG=1 npm run test:inner
 '

--- a/server/test/ci.workflows.test.js
+++ b/server/test/ci.workflows.test.js
@@ -9,10 +9,9 @@ import yaml from 'js-yaml';
 // against a dirty database — never a fresh one — and the idempotency signal is
 // not a comparison at all.
 //
-// js-yaml is a transitive dependency here rather than a declared one; if that
-// ever changes these assertions should move to raw-text matching rather than
-// pulling in a dependency for a lint-shaped check.
 const workflows = ['ci.yml', 'build-test.yml'];
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 function testSteps(file) {
   const doc = yaml.load(fs.readFileSync(path.join('.github/workflows', file), 'utf8'));
@@ -21,6 +20,19 @@ function testSteps(file) {
 }
 
 describe('CI test passes stay comparable', () => {
+  // This file parses YAML, so js-yaml has to be a declared dependency. It was
+  // previously reachable only as a transitive of eslint and markdown-link-check,
+  // which means a dependency bump — one is already open — could remove it and
+  // break this suite with a module-not-found that has nothing to do with CI.
+  it('declares js-yaml rather than relying on a transitive copy', () => {
+    const declared = {
+      ...(pkg.dependencies || {}),
+      ...(pkg.devDependencies || {}),
+      ...(pkg.optionalDependencies || {})
+    };
+    expect(Object.keys(declared)).toContain('js-yaml');
+  });
+
   for (const file of workflows) {
     it(`${file} has both passes`, () => {
       const steps = testSteps(file);

--- a/server/test/rpc.db.postgres.test.js
+++ b/server/test/rpc.db.postgres.test.js
@@ -1,7 +1,5 @@
 import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
 import request from 'supertest';
-import fs from 'node:fs';
-import path from 'node:path';
 import { Pool } from 'pg';
 import app, { __setDbPool } from '../rpc.js';
 import { canonicalizeSorted, canonicalizeJCS, sha256Hex } from '../utils.js';
@@ -14,31 +12,35 @@ const suite = shouldRun ? describe : describe.skip;
 
 suite('Postgres-backed RPC integration', () => {
   let pool;
+  // Unique to this file: the 00000000-… space it used previously is shared by
+  // nine other test files.
+  const ROUND_ID = '0b8e0000-0000-0000-0000-000000000002';
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: dbUrl });
     __setDbPool(pool);
 
-    const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
-    const rpcSql = fs.readFileSync(path.resolve('db/rpc.sql'), 'utf8');
-    await pool.query(schemaSql);
-    await pool.query(rpcSql);
+    // The database is prepared once by `npm run test:prepare-db` before the
+    // suite runs. Re-applying db/schema.sql here re-ran its leading
+    // `DROP TABLE IF EXISTS admin_audit_log CASCADE`, taking schema-wide
+    // ACCESS EXCLUSIVE locks while sibling test files were mid-query — which
+    // is what deadlocked the DB-gated suites, not the TRUNCATE below it.
 
     await pool.query(
       `insert into rooms (id, title)
-       values ('00000000-0000-0000-0000-000000000001', 'Local Demo Room')
+       values ('0b8e0000-0000-0000-0000-000000000001', 'Local Demo Room')
        on conflict (id) do nothing`
     );
     await pool.query(
       `insert into rounds (id, room_id, idx, phase, submit_deadline_unix)
-       values ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 0, 'submit', 0)
+       values ('0b8e0000-0000-0000-0000-000000000002', '0b8e0000-0000-0000-0000-000000000001', 0, 'submit', 0)
        on conflict (id) do nothing`
     );
     await pool.query(
       `insert into participants (id, room_id, anon_name, role)
        values
-         ('00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000001', 'pg-author', 'debater'),
-         ('00000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000001', 'pg-voter', 'debater')
+         ('0b8e0000-0000-0000-0000-000000000003', '0b8e0000-0000-0000-0000-000000000001', 'pg-author', 'debater'),
+         ('0b8e0000-0000-0000-0000-000000000004', '0b8e0000-0000-0000-0000-000000000001', 'pg-voter', 'debater')
        on conflict (id) do nothing`
     );
   });
@@ -49,22 +51,24 @@ suite('Postgres-backed RPC integration', () => {
   });
 
   beforeEach(async () => {
-    const tables = ['submission_flags', 'submissions', 'votes'];
-    const existing = [];
-    for (const table of tables) {
-      const res = await pool.query('select to_regclass($1) as reg', [`public.${table}`]);
-      if (res.rows[0]?.reg) existing.push(`"public"."${table}"`);
-    }
-    if (existing.length > 0) {
-      await pool.query(`TRUNCATE ${existing.join(', ')} RESTART IDENTITY CASCADE;`);
-    }
+    // Delete only this file's own rows, scoped by its round. The previous
+    // TRUNCATE emptied submissions, votes and submission_flags outright —
+    // shared tables that nine other test files write to — under an ACCESS
+    // EXCLUSIVE lock, so it both deadlocked against and silently destroyed
+    // their fixtures.
+    await pool.query(
+      'delete from submission_flags where submission_id in (select id from submissions where round_id = $1)',
+      [ROUND_ID]
+    );
+    await pool.query('delete from submissions where round_id = $1', [ROUND_ID]);
+    await pool.query('delete from votes where round_id = $1', [ROUND_ID]);
   });
 
   it('persists submissions through submission_upsert', async () => {
     const body = {
-      room_id: '00000000-0000-0000-0000-000000000001',
-      round_id: '00000000-0000-0000-0000-000000000002',
-      author_id: '00000000-0000-0000-0000-000000000003',
+      room_id: '0b8e0000-0000-0000-0000-000000000001',
+      round_id: '0b8e0000-0000-0000-0000-000000000002',
+      author_id: '0b8e0000-0000-0000-0000-000000000003',
       phase: 'submit',
       deadline_unix: 0,
       content: 'Hello from pg',
@@ -108,13 +112,13 @@ suite('Postgres-backed RPC integration', () => {
           set phase='published',
               published_at_unix = $1::bigint,
               continue_vote_close_unix = $2::bigint
-        where id = '00000000-0000-0000-0000-000000000002'`,
+        where id = '0b8e0000-0000-0000-0000-000000000002'`,
       [now, now + 60]
     );
     const body = {
-      room_id: '00000000-0000-0000-0000-000000000001',
-      round_id: '00000000-0000-0000-0000-000000000002',
-      voter_id: '00000000-0000-0000-0000-000000000004',
+      room_id: '0b8e0000-0000-0000-0000-000000000001',
+      round_id: '0b8e0000-0000-0000-0000-000000000002',
+      voter_id: '0b8e0000-0000-0000-0000-000000000004',
       choice: 'continue',
       client_nonce: 'pg-vote-1234'
     };

--- a/server/test/rpc.db.verify.test.js
+++ b/server/test/rpc.db.verify.test.js
@@ -1,7 +1,5 @@
 import { describe, it, beforeAll, afterAll, beforeEach, expect } from 'vitest';
 import request from 'supertest';
-import fs from 'node:fs';
-import path from 'node:path';
 import { Pool } from 'pg';
 import app, { __setDbPool } from '../rpc.js';
 
@@ -13,17 +11,17 @@ const suite = shouldRun ? describe : describe.skip;
 
 suite('Postgres-backed verification RPCs', () => {
   let pool;
+  const ROUND_ID = '30000000-0000-0000-0000-000000000002';
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: dbUrl });
     __setDbPool(pool);
 
-    const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
-    const rpcSql = fs.readFileSync(path.resolve('db/rpc.sql'), 'utf8');
-    const rlsSql = fs.readFileSync(path.resolve('db/rls.sql'), 'utf8');
-    await pool.query(schemaSql);
-    await pool.query(rpcSql);
-    await pool.query(rlsSql);
+    // The database is prepared once by `npm run test:prepare-db` before the
+    // suite runs. Re-applying db/schema.sql here re-ran its leading
+    // `DROP TABLE IF EXISTS admin_audit_log CASCADE`, taking schema-wide
+    // ACCESS EXCLUSIVE locks while sibling test files were mid-query — which
+    // is what deadlocked the DB-gated suites, not the TRUNCATE below it.
 
     // Fail fast if critical tables are missing
     const regs = await pool.query(
@@ -59,17 +57,11 @@ suite('Postgres-backed verification RPCs', () => {
   });
 
   beforeEach(async () => {
-    const tables = ['verification_verdicts', 'submissions'];
-    const existing = [];
-    for (const table of tables) {
-      const res = await pool.query('select to_regclass($1) as reg', [`public.${table}`]);
-      if (res.rows[0]?.reg) existing.push(`"public"."${table}"`);
-    }
-    if (existing.length > 0) {
-      await pool.query(`TRUNCATE ${existing.join(', ')} RESTART IDENTITY CASCADE;`);
-      // eslint-disable-next-line no-console
-      console.log('[truncate]', existing.join(', '));
-    }
+    // Scoped to this file's own round. The previous TRUNCATE emptied
+    // verification_verdicts and submissions outright, which are shared with
+    // other suites, under an ACCESS EXCLUSIVE lock.
+    await pool.query('delete from verification_verdicts where round_id = $1', [ROUND_ID]);
+    await pool.query('delete from submissions where round_id = $1', [ROUND_ID]);
   });
 
   it('verify_submit stores and verify_summary aggregates', async () => {

--- a/server/test/watcher.db.flip.test.js
+++ b/server/test/watcher.db.flip.test.js
@@ -17,10 +17,6 @@ suite('Watcher DB flips', () => {
   beforeAll(async () => {
     pool = new Pool({ connectionString: dbUrl });
     // Always apply schema/RPC/RLS to keep isolated and deterministic
-    const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
-    await pool.query(schemaSql);
-    const rpcSql = fs.readFileSync(path.resolve('db/rpc.sql'), 'utf8');
-    await pool.query(rpcSql);
     const rlsSql = fs.readFileSync(path.resolve('db/rls.sql'), 'utf8');
     await pool.query(rlsSql);
     const helpersSql = fs.readFileSync(path.resolve('db/test/helpers.sql'), 'utf8');


### PR DESCRIPTION
Stacked on #177, which it supersedes in part: this removes the `--no-file-parallelism` workaround that PR added.

## I had the diagnosis wrong

In #177 I attributed the intermittent deadlocks to `TRUNCATE` on shared tables and contained them by serialising. **TRUNCATE was not the cause.**

Three files re-applied the schema in `beforeAll`:

```js
const schemaSql = fs.readFileSync(path.resolve('db/schema.sql'), 'utf8');
await pool.query(schemaSql);
```

`db/schema.sql` opens with `DROP TABLE IF EXISTS admin_audit_log CASCADE`. So every one of those files was **dropping and recreating tables** — schema-wide `ACCESS EXCLUSIVE` locks — while sibling files were mid-query. `rpc.db.verify.test.js` re-applied `db/rls.sql` on top, dropping and recreating every policy.

All of it redundant: `test:prepare-db` already prepares the database once before the suite runs.

## Changes

- **Remove the schema/rls re-application** from `rpc.db.postgres.test.js`, `rpc.db.verify.test.js`, `watcher.db.flip.test.js`.
- **Replace the two `TRUNCATE`s with round-scoped deletes.** Beyond the lock, `TRUNCATE` emptied `submissions`, `votes`, `submission_flags` and `verification_verdicts` outright — shared tables — so those files were silently destroying other suites' fixtures mid-run. That is almost certainly behind some of the flakiness this repo has been chasing since `4202a85 test: avoid shared DB state coupling`.
- **Move `rpc.db.postgres.test.js` off the `00000000-…` id space**, which nine other test files also use, onto `0b8e0000-…`.
- **Drop `--no-file-parallelism`** from `ci.yml`, `build-test.yml` and `test-docker.sh`.

Sharing fixture ids is survivable while every writer is additive. It is not survivable next to a `TRUNCATE`. The two together are why this only ever failed *intermittently* rather than every run.

## Tests

| | before | after |
| --- | --- | --- |
| gated, parallel | 4 failed, then 2, then 1 (flaky) | **120 passed × 5 consecutive runs** |
| pass 1 (fresh, parallel) | — | 113 passed |
| pass 2 (reused, gated, parallel) | — | 120 passed |

`eslint` clean, YAML and bash validated.

## Merge order

**#179 → #177 → this → #178.**

@codex this answers the question I left on #177 — serialisation is no longer needed, so the interim is withdrawn rather than shipped.