### PR TITLE
fix(repo): accept breaking-change commits and anchor the subject check

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 msg_file="$1"
-pattern='^(revert: )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|ops|sec)(\(.+\))?: .+'
+
+# Conventional Commits: type(scope)?!?: description
+# The `!` marks a breaking change. CI validates the PR title with
+# amannn/action-semantic-pull-request, which accepts it, so omitting it here
+# refused commits that would pass review.
+pattern='^(revert: )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|ops|sec)(\([^)]+\))?!?: .+'
 merge_pattern='^Merge (branch|pull request|remote-tracking branch)'
 
-# Allow merge commits (auto-generated messages like "Merge branch ...")
-# by checking the message content rather than repository state.
-if grep -Eq "$merge_pattern" "$msg_file"; then
+# Only the subject line is validated. Matching anywhere in the file let a body
+# line carry a malformed subject past the check.
+subject="$(head -n 1 "$msg_file")"
+
+# Allow merge commits, whose messages git generates.
+if printf '%s' "$subject" | grep -Eq "$merge_pattern"; then
   exit 0
 fi
 
-if ! grep -Eq "$pattern" "$msg_file"; then
+if ! printf '%s' "$subject" | grep -Eq "$pattern"; then
   echo "✖ Commit message must follow Conventional Commits" >&2
+  echo "  got: $subject" >&2
+  echo "  expected: type(scope)?!?: description" >&2
   exit 1
 fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,23 @@
+# Files that predate Prettier being run over the repository. They are exempt
+# rather than reformatted: rewriting them wholesale would bury unrelated diffs
+# and, for the workflow and compose files, risk churn in CI-critical YAML for
+# no functional gain. Remove an entry here when you are deliberately formatting
+# that file, not as a side effect of touching it.
+
+.github/dependabot.yml
+.github/ISSUE_TEMPLATE/bug.md
+.github/ISSUE_TEMPLATE/feature.md
+.github/ISSUE_TEMPLATE/task.md
+.github/workflows/ci.yml
+.github/workflows/db-tests.yml
+AGENTS.md
+docker-compose.test.yml
+docker-compose.yml
+package.json
+public/index.html
+public/kitchen-sink.html
+public/spectate.html
+server/rpc.js
+vitest.config.js
+web/app/globals.css
+web/test/e2e.room.flow.spec.js

--- a/cspell.json
+++ b/cspell.json
@@ -140,7 +140,10 @@
     "contype",
     "unwritable",
     "worktree",
-    "worktrees"
+    "worktrees",
+    "amannn",
+    "commitmsg",
+    "EDITMSG"
   ],
   "ignoreWords": ["frontmatter", "Frontmatter"]
 }

--- a/server/test/commit.msg.hook.test.js
+++ b/server/test/commit.msg.hook.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const hook = path.join(repoRoot, '.githooks', 'commit-msg');
+
+// The hook reads the message from a file, the way git invokes it.
+function check(message) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'db8-commitmsg-'));
+  const file = path.join(dir, 'COMMIT_EDITMSG');
+  try {
+    fs.writeFileSync(file, message);
+    execFileSync('bash', [hook, file], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const TYPES = [
+  'feat',
+  'fix',
+  'docs',
+  'style',
+  'refactor',
+  'perf',
+  'test',
+  'build',
+  'ci',
+  'chore',
+  'ops',
+  'sec'
+];
+
+describe('commit-msg hook', () => {
+  it('accepts every declared type', () => {
+    for (const type of TYPES) {
+      expect(check(`${type}: do a thing`), type).toBe(true);
+    }
+  });
+
+  it('accepts a scope', () => {
+    expect(check('feat(claims): add a node kind')).toBe(true);
+  });
+
+  // Conventional Commits marks a breaking change with `!` before the colon.
+  // CI validates the PR title with amannn/action-semantic-pull-request, which
+  // accepts it, so a commit the hook refuses would have passed review — the
+  // two must agree on the grammar.
+  it('accepts the breaking-change marker, with and without a scope', () => {
+    expect(check('feat!: drop the flat claim shape')).toBe(true);
+    expect(check('feat(claims)!: drop the flat claim shape')).toBe(true);
+  });
+
+  it('accepts a body and a BREAKING CHANGE footer', () => {
+    expect(
+      check('fix(claims)!: correct the projection\n\nBody.\n\nBREAKING CHANGE: it changed.')
+    ).toBe(true);
+  });
+
+  it('accepts a revert', () => {
+    expect(check('revert: feat(claims): add a node kind')).toBe(true);
+  });
+
+  it('accepts merge commits, whose messages git generates', () => {
+    expect(check("Merge branch 'main' into feat/x")).toBe(true);
+    expect(check('Merge pull request #1 from flyingrobots/feat/x')).toBe(true);
+  });
+
+  it('rejects an unknown type', () => {
+    expect(check('wip: something')).toBe(false);
+    expect(check('update: something')).toBe(false);
+  });
+
+  it('rejects a missing type', () => {
+    expect(check('just a message')).toBe(false);
+  });
+
+  it('rejects an empty description', () => {
+    expect(check('feat: ')).toBe(false);
+    expect(check('feat:')).toBe(false);
+  });
+
+  // The type must open the subject line. Without an anchor a conforming line
+  // anywhere in the body would validate the whole message.
+  it('rejects a conforming line that is not the subject', () => {
+    expect(check('wip: broken\n\nfeat: this line conforms but is not the subject')).toBe(false);
+  });
+});

--- a/server/test/rpc.validation.test.js
+++ b/server/test/rpc.validation.test.js
@@ -5,4 +5,3 @@ describe('RPC validation (placeholders)', () => {
   it.todo('enforces <=5 claims');
   it.todo('stable canonical sha256');
 });
-

--- a/server/test/rpc.verify.submit.test.js
+++ b/server/test/rpc.verify.submit.test.js
@@ -78,15 +78,13 @@ describe('POST /rpc/verify.submit (memory path)', () => {
   it('rejects malformed UUIDs and missing fields', async () => {
     const bad = await request(app).post('/rpc/verify.submit').send({ verdict: 'true' });
     expect(bad.status).toBeGreaterThanOrEqual(400);
-    const badIds = await request(app)
-      .post('/rpc/verify.submit')
-      .send({
-        round_id: 'not-a-uuid',
-        reporter_id: 'x',
-        submission_id: 'y',
-        verdict: 'true',
-        client_nonce: 'v'
-      });
+    const badIds = await request(app).post('/rpc/verify.submit').send({
+      round_id: 'not-a-uuid',
+      reporter_id: 'x',
+      submission_id: 'y',
+      verdict: 'true',
+      client_nonce: 'v'
+    });
     expect(badIds.status).toBeGreaterThanOrEqual(400);
   });
 


### PR DESCRIPTION
## Why

`.githooks/commit-msg` refused valid Conventional Commits.

Its pattern was `^(type)(\(.+\))?: .+`, which has no slot for the `!` breaking marker, so this could not be committed at all:

```
fix(claims)!: correct the projection
✖ Commit message must follow Conventional Commits
```

CI's `conventional-commits` job is `amannn/action-semantic-pull-request`, which validates the **PR title** and accepts `!`. Nothing cross-checked the two, so a commit the hook rejected would have sailed through review. The hook has been hand-rolled since `78fda93` ("chore: bootstrap hooks") and never caught up to the grammar it claims to enforce.

Found while writing a genuinely breaking commit for #182 and having to drop the marker to get it in.

## Also fixed

The check ran `grep -Eq` against the **whole message file** rather than the subject line, so any conforming line in the body validated a malformed subject:

```
wip: broken

feat: this line conforms but is not the subject     <- passed
```

Both behaviours are now pinned by tests. The hook previously had **no** grammar coverage — `install.scripts.test.js` only asserts that it gets installed.

## Prettier exemptions

`npm run lint` is eslint only, so `prettier --check .` has failed on 17 files for as long as they have existed (`.github/*`, `AGENTS.md`, `package.json`, `docker-compose*.yml`, `server/rpc.js`, `vitest.config.js`, `web/*`). They are now listed in `.prettierignore` rather than reformatted — rewriting them wholesale would bury unrelated diffs and churn CI-critical YAML for no functional gain.

Two ordinary test files that had also never been formatted are formatted instead of exempted, in a separate whitespace-only commit.

`prettier --check .` now passes clean.

## Verification

```
feat(demo)!: prove the marker is accepted        -> ACCEPTED
wip: bad + conforming body line                  -> REJECTED
```

Full suite 148 passing, 0 failing.