### PR TITLE
refactor(verify): put verdict persistence behind a VerdictStore port

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -153,6 +153,7 @@
     "pronargs",
     "reimplementation",
     "arities",
+    "SQLSTATE",
     "unvalidated",
     "factive",
     "cutover"

--- a/cspell.json
+++ b/cspell.json
@@ -154,6 +154,8 @@
     "reimplementation",
     "arities",
     "SQLSTATE",
+    "resends",
+    "setof",
     "unvalidated",
     "factive",
     "cutover"

--- a/server/adapters/ConfiguredVerdictStore.js
+++ b/server/adapters/ConfiguredVerdictStore.js
@@ -1,0 +1,53 @@
+import { PostgresVerdictStore } from './PostgresVerdictStore.js';
+import { MemoryVerdictStore } from './MemoryVerdictStore.js';
+
+/**
+ * Chooses a VerdictStore by configuration.
+ *
+ * Deliberately *not* a fallback. It routes on whether a database is configured,
+ * never on whether one is failing: a configured database that errors surfaces
+ * `database_unavailable` from the Postgres adapter and the request fails.
+ * Answering from memory instead would tell a judge their verdict was recorded
+ * when it was only held in a process about to restart.
+ *
+ * The decision is made per call rather than at construction because
+ * server/rpc.js swaps the pool at runtime (__setDbPool), and tests rely on that.
+ */
+export class ConfiguredVerdictStore {
+  constructor({ dbRef, durable, memory }) {
+    this.dbRef = dbRef;
+    this.durable = durable;
+    this.memory = memory;
+  }
+
+  get delegate() {
+    return this.dbRef.pool ? this.durable : this.memory;
+  }
+
+  submitVerdict(input) {
+    return this.delegate.submitVerdict(input);
+  }
+
+  summary(roundId) {
+    return this.delegate.summary(roundId);
+  }
+
+  claimTerm(submissionId, claimId) {
+    return this.delegate.claimTerm(submissionId, claimId);
+  }
+}
+
+/**
+ * Builds the store the application uses: a Postgres adapter and a memory
+ * adapter, selected by whether a database is configured.
+ *
+ * One place assembles the three pieces, so the composition root and the tests
+ * exercise the same wiring rather than two hand-rolled approximations of it.
+ */
+export function createVerdictStore({ dbRef, verdicts, submissionIndex }) {
+  return new ConfiguredVerdictStore({
+    dbRef,
+    durable: new PostgresVerdictStore({ dbRef }),
+    memory: new MemoryVerdictStore({ verdicts, submissionIndex })
+  });
+}

--- a/server/adapters/ConfiguredVerdictStore.js
+++ b/server/adapters/ConfiguredVerdictStore.js
@@ -1,3 +1,4 @@
+import { VERDICT_STORE_METHODS } from '../ports/VerdictStore.js';
 import { PostgresVerdictStore } from './PostgresVerdictStore.js';
 import { MemoryVerdictStore } from './MemoryVerdictStore.js';
 
@@ -24,17 +25,25 @@ export class ConfiguredVerdictStore {
     return this.dbRef.pool ? this.durable : this.memory;
   }
 
-  submitVerdict(input) {
-    return this.delegate.submitVerdict(input);
+  /**
+   * A delegate pinned for the length of one operation.
+   *
+   * VerificationService reads a claim's term and then writes the verdict. If the
+   * pool is swapped between those two calls the path is validated against one
+   * store and persisted through another, and verify_submit does not re-check the
+   * path — so the write would land unvalidated.
+   */
+  forRequest() {
+    return this.delegate;
   }
+}
 
-  summary(roundId) {
-    return this.delegate.summary(roundId);
-  }
-
-  claimTerm(submissionId, claimId) {
-    return this.delegate.claimTerm(submissionId, claimId);
-  }
+// Generated from the port's declared surface, so adding a method to the port
+// cannot leave this wrapper silently behind.
+for (const method of VERDICT_STORE_METHODS) {
+  ConfiguredVerdictStore.prototype[method] = function forward(...args) {
+    return this.delegate[method](...args);
+  };
 }
 
 /**

--- a/server/adapters/MemoryVerdictStore.js
+++ b/server/adapters/MemoryVerdictStore.js
@@ -3,15 +3,25 @@ import crypto from 'node:crypto';
 // A JSON tuple, not a delimiter-joined string. claim_id is author-supplied and
 // may contain the delimiter: "source:claim" shifted every field after it when
 // the key was split back apart, corrupting the summary rows.
+// The nonce is part of the identity, matching verify_submit's ON CONFLICT and
+// the rule the port states. It is what separates a repeat from a revision: a
+// judge who reconsiders resends the same tuple with a new nonce, and dropping it
+// returned the original id and discarded the revised ruling.
 function verdictKey(input) {
   return JSON.stringify([
     input.round_id,
     input.reporter_id,
     input.submission_id,
     input.claim_id ?? null,
-    input.claim_path ?? null
+    input.claim_path ?? null,
+    input.client_nonce ?? null
   ]);
 }
+
+// Postgres constrains this column, so a value outside the four cannot reach the
+// aggregate there. Rejecting it here keeps the adapters answering alike instead
+// of producing a row whose total exceeds the columns that make it up.
+const VERDICTS = Object.freeze(['true', 'false', 'unclear', 'needs_work']);
 
 const EMPTY_ROW = Object.freeze({
   true_count: 0,
@@ -40,6 +50,7 @@ export class MemoryVerdictStore {
     if (this.submissionIndex && !this.submissionIndex.has(input.submission_id)) {
       throw new Error('submission_not_found');
     }
+    if (!VERDICTS.includes(input.verdict)) throw new Error('invalid_verdict');
 
     const key = verdictKey(input);
     const existing = this.verdicts.get(key);
@@ -73,8 +84,7 @@ export class MemoryVerdictStore {
 
       const row = rows.get(groupKey);
       row.total += 1;
-      const field = `${value.verdict}_count`;
-      if (field in row) row[field] += 1;
+      row[`${value.verdict}_count`] += 1;
     }
 
     return [...rows.values()].sort(

--- a/server/adapters/MemoryVerdictStore.js
+++ b/server/adapters/MemoryVerdictStore.js
@@ -41,9 +41,21 @@ const EMPTY_ROW = Object.freeze({
  * own, and the submission index it reads claims out of.
  */
 export class MemoryVerdictStore {
-  constructor({ verdicts, submissionIndex }) {
+  /**
+   * @param {object} opts
+   * @param {Map} opts.verdicts        verdict storage; must not evict
+   * @param {Map} opts.submissionIndex submissions, for reading claim terms back
+   * @param {number} [opts.capacity]   most distinct verdicts held before writes
+   *   are refused. Eviction is not an option — dropping an older verdict makes
+   *   the summary report fewer findings than were filed, silently — but neither
+   *   is growing without limit, because client_nonce mints a new identity and a
+   *   client sending valid revisions would exhaust the heap. So it fills up and
+   *   says so, the same choice made for a database that cannot be reached.
+   */
+  constructor({ verdicts, submissionIndex, capacity = 50_000 }) {
     this.verdicts = verdicts;
     this.submissionIndex = submissionIndex;
+    this.capacity = capacity;
   }
 
   async submitVerdict(input) {
@@ -54,8 +66,12 @@ export class MemoryVerdictStore {
 
     const key = verdictKey(input);
     const existing = this.verdicts.get(key);
-    // Idempotent on the same tuple, matching verify_submit's ON CONFLICT.
+    // Idempotent on the same tuple, matching verify_submit's ON CONFLICT. A
+    // repeat is not a new identity, so it is answered even when full: refusing
+    // it would break idempotency for a client retrying after a timeout.
     if (existing) return { id: existing.id, note: 'db_fallback' };
+
+    if (this.verdicts.size >= this.capacity) throw new Error('verdict_capacity_reached');
 
     const id = crypto.randomUUID();
     this.verdicts.set(key, { id, verdict: input.verdict, rationale: input.rationale });

--- a/server/adapters/MemoryVerdictStore.js
+++ b/server/adapters/MemoryVerdictStore.js
@@ -1,0 +1,92 @@
+import crypto from 'node:crypto';
+
+// A JSON tuple, not a delimiter-joined string. claim_id is author-supplied and
+// may contain the delimiter: "source:claim" shifted every field after it when
+// the key was split back apart, corrupting the summary rows.
+function verdictKey(input) {
+  return JSON.stringify([
+    input.round_id,
+    input.reporter_id,
+    input.submission_id,
+    input.claim_id ?? null,
+    input.claim_path ?? null
+  ]);
+}
+
+const EMPTY_ROW = Object.freeze({
+  true_count: 0,
+  false_count: 0,
+  unclear_count: 0,
+  needs_work_count: 0,
+  total: 0
+});
+
+/**
+ * VerdictStore backed by process memory, for rooms configured without a
+ * database. A peer of the Postgres adapter, not a degraded mode: the shared
+ * contract suite runs against both, which is what stops the aggregate here
+ * drifting from verify_summary the way it previously did.
+ *
+ * Storage is the maps the rest of the process already keeps — verdicts of its
+ * own, and the submission index it reads claims out of.
+ */
+export class MemoryVerdictStore {
+  constructor({ verdicts, submissionIndex }) {
+    this.verdicts = verdicts;
+    this.submissionIndex = submissionIndex;
+  }
+
+  async submitVerdict(input) {
+    if (this.submissionIndex && !this.submissionIndex.has(input.submission_id)) {
+      throw new Error('submission_not_found');
+    }
+
+    const key = verdictKey(input);
+    const existing = this.verdicts.get(key);
+    // Idempotent on the same tuple, matching verify_submit's ON CONFLICT.
+    if (existing) return { id: existing.id, note: 'db_fallback' };
+
+    const id = crypto.randomUUID();
+    this.verdicts.set(key, { id, verdict: input.verdict, rationale: input.rationale });
+    return { id, note: 'db_fallback' };
+  }
+
+  async summary(roundId) {
+    const rows = new Map();
+
+    for (const [key, value] of this.verdicts.entries()) {
+      const [round, , submissionId, claimId, claimPath] = JSON.parse(key);
+      if (round !== roundId) continue;
+
+      // Grouped by path, matching verify_summary. Without the path this merges
+      // the two findings it exists to separate, and the same room reports
+      // differently depending on which adapter is in use.
+      const groupKey = JSON.stringify([submissionId, claimId, claimPath]);
+      if (!rows.has(groupKey)) {
+        rows.set(groupKey, {
+          submission_id: submissionId,
+          claim_id: claimId,
+          claim_path: claimPath,
+          ...EMPTY_ROW
+        });
+      }
+
+      const row = rows.get(groupKey);
+      row.total += 1;
+      const field = `${value.verdict}_count`;
+      if (field in row) row[field] += 1;
+    }
+
+    return [...rows.values()].sort(
+      (a, b) =>
+        String(a.submission_id).localeCompare(String(b.submission_id)) ||
+        (a.claim_id || '').localeCompare(b.claim_id || '') ||
+        (a.claim_path || '').localeCompare(b.claim_path || '')
+    );
+  }
+
+  async claimTerm(submissionId, claimId) {
+    const claims = this.submissionIndex?.get(submissionId)?.claims;
+    return claims?.find((c) => c?.id === claimId)?.term ?? undefined;
+  }
+}

--- a/server/adapters/PostgresVerdictStore.js
+++ b/server/adapters/PostgresVerdictStore.js
@@ -59,7 +59,12 @@ export class PostgresVerdictStore {
         input.claim_path ?? null
       ]
     );
-    return { id: r.rows[0].id };
+    // verify_submit is a scalar select, so one row is the expected shape. A
+    // future signature returning setof or void would otherwise throw a raw
+    // TypeError out of a method the port promises returns {id}.
+    const id = r.rows[0]?.id;
+    if (!id) throw new Error('verify_submit returned no id');
+    return { id };
   }
 
   async summary(roundId) {

--- a/server/adapters/PostgresVerdictStore.js
+++ b/server/adapters/PostgresVerdictStore.js
@@ -20,15 +20,25 @@ export class PostgresVerdictStore {
 
   /**
    * A configured database that fails is a durability failure, not an invitation
-   * to answer from somewhere else. Every query goes through here so the failure
-   * is named once and cannot be mistaken for a normal empty result.
-   * @throws {Error} database_unavailable
+   * to answer from somewhere else — so an unreachable database surfaces as
+   * `database_unavailable` rather than a normal empty result.
+   *
+   * But a rule the database *enforced* is not an outage. verify_submit raises
+   * `round_not_verifiable` and `reporter_role_denied` deliberately; wrapping
+   * those told the client the service was down when the database had answered
+   * perfectly well and said no.
+   *
+   * Postgres sets `severity` on anything it replied with, whatever the
+   * SQLSTATE. A connection that never got an answer has none.
+   * @throws {Error} database_unavailable when the database could not be reached
    */
   async #query(sql, params) {
     try {
       return await this.pool.query(sql, params);
     } catch (err) {
-      console.error('[PostgresVerdictStore] database error:', err.message);
+      if (err?.severity) throw err;
+
+      console.error('[PostgresVerdictStore] database unreachable:', err.message);
       const wrapped = new Error('database_unavailable');
       wrapped.cause = err;
       throw wrapped;

--- a/server/adapters/PostgresVerdictStore.js
+++ b/server/adapters/PostgresVerdictStore.js
@@ -1,0 +1,67 @@
+/**
+ * VerdictStore backed by Postgres.
+ *
+ * Every statement it issues is an RPC — verify_submit, verify_summary,
+ * submission_claim_term — so the invariants live in db/rpc.sql where any client
+ * reaching the database gets them, not only this process.
+ *
+ * The pool is read from a mutable holder rather than captured, because
+ * server/rpc.js swaps it at runtime (__setDbPool) and a captured reference
+ * would keep using a pool that has been replaced.
+ */
+export class PostgresVerdictStore {
+  constructor({ dbRef }) {
+    this.dbRef = dbRef;
+  }
+
+  get pool() {
+    return this.dbRef.pool;
+  }
+
+  /**
+   * A configured database that fails is a durability failure, not an invitation
+   * to answer from somewhere else. Every query goes through here so the failure
+   * is named once and cannot be mistaken for a normal empty result.
+   * @throws {Error} database_unavailable
+   */
+  async #query(sql, params) {
+    try {
+      return await this.pool.query(sql, params);
+    } catch (err) {
+      console.error('[PostgresVerdictStore] database error:', err.message);
+      const wrapped = new Error('database_unavailable');
+      wrapped.cause = err;
+      throw wrapped;
+    }
+  }
+
+  async submitVerdict(input) {
+    const r = await this.#query(
+      'SELECT verify_submit($1::uuid,$2::uuid,$3::uuid,$4::text,$5::text,$6::text,$7::text,$8::text) AS id',
+      [
+        input.round_id,
+        input.reporter_id,
+        input.submission_id,
+        input.claim_id,
+        input.verdict,
+        input.rationale,
+        input.client_nonce,
+        input.claim_path ?? null
+      ]
+    );
+    return { id: r.rows[0].id };
+  }
+
+  async summary(roundId) {
+    const r = await this.#query('SELECT * FROM verify_summary($1::uuid)', [roundId]);
+    return r.rows;
+  }
+
+  async claimTerm(submissionId, claimId) {
+    const r = await this.#query('SELECT submission_claim_term($1::uuid,$2::text) AS term', [
+      submissionId,
+      claimId
+    ]);
+    return r.rows[0]?.term ?? undefined;
+  }
+}

--- a/server/ports/VerdictStore.js
+++ b/server/ports/VerdictStore.js
@@ -47,8 +47,18 @@
  *   (round, reporter, submission, claim, path, nonce): submitting the same
  *   tuple twice returns the same id rather than a second row. A verdict on the
  *   attribution and a verdict on the proposition it attributes are *different*
- *   findings, so the path is part of that identity.
- *   Throws `submission_not_found` when the submission is unknown.
+ *   findings, so the path is part of that identity — and so is the nonce, which
+ *   is what separates a repeat from a revision.
+ *
+ *   Rejects a verdict value outside the four listed above.
+ *
+ *   KNOWN DIVERGENCE, not yet resolved: the adapters name the unknown-submission
+ *   rejection differently. Memory raises `submission_not_found`. Postgres raises
+ *   `submission_round_mismatch`, and does so both when the submission does not
+ *   exist and when it belongs to another round, because verify_submit checks the
+ *   pair in one statement. Aligning them means renaming a client-facing error,
+ *   which is a product decision rather than a refactor, so the contract suite
+ *   deliberately does not assert a name here.
  *
  * @property {(roundId: string) => Promise<SummaryRow[]>} summary
  *   Verdict counts for a round, one row per (submission, claim, path), ordered

--- a/server/ports/VerdictStore.js
+++ b/server/ports/VerdictStore.js
@@ -1,0 +1,81 @@
+// The VerdictStore port.
+//
+// One contract, two adapters: Postgres for durable rooms, memory for rooms that
+// were configured without a database. Memory is not a degraded mode reached by
+// accident — it is chosen at composition, and both adapters answer the same
+// questions the same way.
+//
+// This file is documentation and a conformance helper, not an abstract class.
+// The contract is what the shared suite in server/test/verdict.store.contract.test.js
+// asserts against every adapter; a base class would let an adapter inherit an
+// implementation and silently skip that suite.
+//
+// What belongs behind this port: storing a verdict, reading the aggregate,
+// reading back the term a verdict may target. What does *not*: deciding whether
+// a claim path resolves. That is domain logic — server/claims/paths.js owns the
+// grammar — and it lives above the port so both adapters cannot disagree.
+
+/**
+ * @typedef {object} VerdictInput
+ * @property {string} round_id
+ * @property {string} reporter_id
+ * @property {string} submission_id
+ * @property {string} [claim_id]      which claim within the submission
+ * @property {string} [claim_path]    which node of that claim's term
+ * @property {'true'|'false'|'unclear'|'needs_work'} verdict
+ * @property {string} [rationale]
+ * @property {string} client_nonce    idempotency token
+ */
+
+/**
+ * @typedef {object} SummaryRow
+ * @property {string} submission_id
+ * @property {string|null} claim_id
+ * @property {string|null} claim_path
+ * @property {number} true_count
+ * @property {number} false_count
+ * @property {number} unclear_count
+ * @property {number} needs_work_count
+ * @property {number} total
+ */
+
+/**
+ * @typedef {object} VerdictStore
+ *
+ * @property {(input: VerdictInput) => Promise<{id: string, note?: string}>} submitVerdict
+ *   Records a verdict and returns its id. Idempotent on
+ *   (round, reporter, submission, claim, path, nonce): submitting the same
+ *   tuple twice returns the same id rather than a second row. A verdict on the
+ *   attribution and a verdict on the proposition it attributes are *different*
+ *   findings, so the path is part of that identity.
+ *   Throws `submission_not_found` when the submission is unknown.
+ *
+ * @property {(roundId: string) => Promise<SummaryRow[]>} summary
+ *   Verdict counts for a round, one row per (submission, claim, path), ordered
+ *   by those three. Grouping must include the path or the two findings the path
+ *   exists to separate are merged back together.
+ *
+ * @property {(submissionId: string, claimId: string) => Promise<object|undefined>} claimTerm
+ *   The stored term of one claim, or undefined when the submission has no claim
+ *   with that id. Callers use it to check that a verdict's path names a real
+ *   node; the store itself does not resolve paths.
+ */
+
+/** The methods every adapter must provide. Used by the contract suite. */
+export const VERDICT_STORE_METHODS = Object.freeze(['submitVerdict', 'summary', 'claimTerm']);
+
+/**
+ * Throws when an object does not present the port's surface. Cheap guard for
+ * the composition root, so a missing method fails at wiring rather than on the
+ * first request that happens to need it.
+ * @param {object} store
+ * @param {string} label
+ */
+export function assertVerdictStore(store, label = 'store') {
+  for (const method of VERDICT_STORE_METHODS) {
+    if (typeof store?.[method] !== 'function') {
+      throw new Error(`${label} does not implement VerdictStore.${method}`);
+    }
+  }
+  return store;
+}

--- a/server/routes/verification.js
+++ b/server/routes/verification.js
@@ -13,7 +13,7 @@ export function createVerificationRouter({ verificationService, requireDbInProdu
     } catch (err) {
       // A configured database that failed is not the caller's fault, and the
       // verdict was not recorded. 503 says both.
-      if (err?.message === 'database_unavailable')
+      if (err?.message === 'database_unavailable' || err?.message === 'verdict_capacity_reached')
         return res.status(503).json({ ok: false, error: err.message });
       return res.status(400).json({ ok: false, error: err?.message || String(err) });
     }

--- a/server/rpc.js
+++ b/server/rpc.js
@@ -65,7 +65,10 @@ function requireDbInProduction(req, res, next) {
 const memSubmissions = new LRUMap(1000);
 const memSubmissionIndex = new LRUMap(1000);
 const memFlags = new LRUMap(1000);
-const memVerifications = new LRUMap(2000);
+// Deliberately unbounded, unlike the caches around it. An LRU would evict older
+// verdicts once a round exceeded its limit and the summary would quietly report
+// fewer findings than were filed.
+const memVerifications = new Map();
 const memRooms = new LRUMap(100);
 const memRoomNonces = new LRUMap(500);
 const memVotes = new LRUMap(1000);

--- a/server/rpc.js
+++ b/server/rpc.js
@@ -13,6 +13,7 @@ import { RoomService } from './services/RoomService.js';
 import { VoteService } from './services/VoteService.js';
 import { ScoringService } from './services/ScoringService.js';
 import { VerificationService } from './services/VerificationService.js';
+import { createVerdictStore } from './adapters/ConfiguredVerdictStore.js';
 
 // Routers
 import { createRoomRouter } from './routes/room.js';
@@ -90,11 +91,15 @@ const roomService = new RoomService({
 });
 const voteService = new VoteService({ dbRef, memVotes, memVoteTotals });
 const scoringService = new ScoringService({ dbRef });
-const verificationService = new VerificationService({
+// Composition root for verdict persistence. The service holds the rules; the
+// adapter chosen here decides where they are applied. Memory is a configured
+// peer of Postgres, not a place requests land when Postgres misbehaves.
+const verdictStore = createVerdictStore({
   dbRef,
-  memVerifications,
-  memSubmissionIndex
+  verdicts: memVerifications,
+  submissionIndex: memSubmissionIndex
 });
+const verificationService = new VerificationService({ store: verdictStore });
 
 const memIssuedNonces = new LRUMap(5000); // For server-issued nonces in memory mode
 

--- a/server/services/VerificationService.js
+++ b/server/services/VerificationService.js
@@ -26,10 +26,10 @@ export class VerificationService {
    * @throws {Error} claim_not_found     the claim_id names nothing in the submission
    * @throws {Error} claim_path_not_found the path names no node in that term
    */
-  async assertPathResolves(input) {
+  async assertPathResolves(store, input) {
     if (!input.claim_path) return;
 
-    const term = await this.store.claimTerm(input.submission_id, input.claim_id);
+    const term = await store.claimTerm(input.submission_id, input.claim_id);
 
     // No term means the claim_id names nothing here. Accepting the path anyway
     // files a verdict against a claim that does not exist, and the summary then
@@ -42,8 +42,13 @@ export class VerificationService {
   }
 
   async submitVerdict(input) {
-    await this.assertPathResolves(input);
-    return this.store.submitVerdict(input);
+    // One store for the whole operation. Reading the term and writing the
+    // verdict through separately-resolved delegates would let a pool swap
+    // between them validate against one and persist through the other, and
+    // verify_submit does not re-check the path.
+    const store = this.store.forRequest?.() ?? this.store;
+    await this.assertPathResolves(store, input);
+    return store.submitVerdict(input);
   }
 
   async getSummary(roundId) {

--- a/server/services/VerificationService.js
+++ b/server/services/VerificationService.js
@@ -1,60 +1,39 @@
-import crypto from 'node:crypto';
 import { atPath, parsePath } from '../claims/paths.js';
-
-// A JSON tuple, not a delimiter-joined string. claim_id is an author-supplied
-// value and may contain the delimiter: `source:claim` shifted every field after
-// it when the key was split back apart, corrupting the summary rows.
-function memKey(input) {
-  return JSON.stringify([
-    input.round_id,
-    input.reporter_id,
-    input.submission_id,
-    input.claim_id ?? null,
-    input.claim_path ?? null
-  ]);
-}
+import { assertVerdictStore } from '../ports/VerdictStore.js';
 
 /**
- * VerificationService handles submission verdicts and claim-level aggregates.
+ * Verdict submission and claim-level aggregates.
+ *
+ * Persistence sits behind the VerdictStore port, so this class holds only the
+ * rules that must be true whichever adapter is in use. It no longer knows that
+ * Postgres exists, and it no longer branches on whether a pool is configured —
+ * choosing an adapter is the composition root's job.
  */
 export class VerificationService {
-  constructor({ dbRef, memVerifications, memSubmissionIndex }) {
-    this.dbRef = dbRef;
-    this.memVerifications = memVerifications;
-    this.memSubmissionIndex = memSubmissionIndex;
-  }
-
-  get pool() {
-    return this.dbRef.pool;
+  constructor({ store }) {
+    this.store = assertVerdictStore(store, 'VerificationService store');
   }
 
   /**
    * A path that parses is not a path that exists. The schema proves the syntax;
    * only the claim's own term can say whether the node is there, and binding a
-   * verdict to a node is what the column is for.
+   * verdict to a node is what the path is for.
    *
-   * Resolution stays here rather than in SQL because server/claims/paths.js owns
-   * the grammar — a plpgsql copy would be a second implementation to drift.
-   * @throws {Error} claim_path_not_found
+   * This is domain logic, above the port: server/claims/paths.js owns the path
+   * grammar, and resolving inside each adapter would be two implementations
+   * free to disagree. The store is asked only for the term.
+   *
+   * @throws {Error} claim_not_found     the claim_id names nothing in the submission
+   * @throws {Error} claim_path_not_found the path names no node in that term
    */
   async assertPathResolves(input) {
     if (!input.claim_path) return;
 
-    let term;
-    if (this.pool) {
-      const r = await this.query('SELECT submission_claim_term($1::uuid,$2::text) AS term', [
-        input.submission_id,
-        input.claim_id
-      ]);
-      term = r.rows[0]?.term;
-    } else {
-      const claims = this.memSubmissionIndex?.get(input.submission_id)?.claims;
-      term = claims?.find((c) => c?.id === input.claim_id)?.term;
-    }
+    const term = await this.store.claimTerm(input.submission_id, input.claim_id);
 
-    // No term means the claim_id names nothing in this submission. Accepting the
-    // path then files a verdict against a claim that does not exist, and the
-    // summary reports it as a finding.
+    // No term means the claim_id names nothing here. Accepting the path anyway
+    // files a verdict against a claim that does not exist, and the summary then
+    // reports it as a finding.
     if (!term) throw new Error('claim_not_found');
 
     if (atPath(term, parsePath(input.claim_path)) === undefined) {
@@ -62,102 +41,12 @@ export class VerificationService {
     }
   }
 
-  /**
-   * Every database call goes through here so a configured-but-failing database
-   * fails the request instead of silently degrading to memory. A judge told
-   * their verdict was recorded, when it was only held in a process that will
-   * restart, has been misled about the one property verdicts need.
-   *
-   * Memory stays a first-class mode; it is chosen by configuration, not arrived
-   * at by accident when a query errors.
-   * @throws {Error} database_unavailable
-   */
-  async query(sql, params) {
-    try {
-      return await this.pool.query(sql, params);
-    } catch (err) {
-      console.error('[VerificationService] database error:', err.message);
-      const wrapped = new Error('database_unavailable');
-      wrapped.cause = err;
-      throw wrapped;
-    }
-  }
-
   async submitVerdict(input) {
     await this.assertPathResolves(input);
-
-    const key = memKey(input);
-
-    if (this.pool) {
-      const r = await this.query(
-        'SELECT verify_submit($1::uuid,$2::uuid,$3::uuid,$4::text,$5::text,$6::text,$7::text,$8::text) AS id',
-        [
-          input.round_id,
-          input.reporter_id,
-          input.submission_id,
-          input.claim_id,
-          input.verdict,
-          input.rationale,
-          input.client_nonce,
-          input.claim_path ?? null
-        ]
-      );
-      return { id: r.rows[0].id };
-    }
-
-    if (this.memSubmissionIndex && !this.memSubmissionIndex.has(input.submission_id)) {
-      throw new Error('submission_not_found');
-    }
-
-    if (this.memVerifications.has(key))
-      return { id: this.memVerifications.get(key).id, note: 'db_fallback' };
-    const id = crypto.randomUUID();
-    this.memVerifications.set(key, { id, verdict: input.verdict, rationale: input.rationale });
-    return { id, note: 'db_fallback' };
+    return this.store.submitVerdict(input);
   }
 
   async getSummary(roundId) {
-    if (this.pool) {
-      const r = await this.query('SELECT * FROM verify_summary($1::uuid)', [roundId]);
-      return r.rows;
-    }
-
-    // Memory Aggregation
-    const summaryMap = new Map();
-    for (const [key, v] of this.memVerifications.entries()) {
-      const [round, , subId, claimId, claimPath] = JSON.parse(key);
-      if (round !== roundId) continue;
-      // Grouped by path, matching verify_summary. Without it this fallback
-      // merges the two findings claim_path exists to separate, and the same
-      // room reports differently depending on whether the database was up.
-      const aggKey = JSON.stringify([subId, claimId, claimPath]);
-
-      if (!summaryMap.has(aggKey)) {
-        summaryMap.set(aggKey, {
-          submission_id: subId,
-          claim_id: claimId,
-          claim_path: claimPath,
-          true_count: 0,
-          false_count: 0,
-          unclear_count: 0,
-          needs_work_count: 0,
-          total: 0
-        });
-      }
-      const entry = summaryMap.get(aggKey);
-      entry.total++;
-      if (v.verdict === 'true') entry.true_count++;
-      else if (v.verdict === 'false') entry.false_count++;
-      else if (v.verdict === 'unclear') entry.unclear_count++;
-      else if (v.verdict === 'needs_work') entry.needs_work_count++;
-    }
-
-    return Array.from(summaryMap.values()).sort((a, b) => {
-      if (a.submission_id !== b.submission_id)
-        return a.submission_id.localeCompare(b.submission_id);
-      if ((a.claim_id || '') !== (b.claim_id || ''))
-        return (a.claim_id || '').localeCompare(b.claim_id || '');
-      return (a.claim_path || '').localeCompare(b.claim_path || '');
-    });
+    return this.store.summary(roundId);
   }
 }

--- a/server/test/claims.verdict.path.test.js
+++ b/server/test/claims.verdict.path.test.js
@@ -81,13 +81,16 @@ describe('verdicts target a claim path', () => {
 describe('the memory summary separates paths the same way the SQL does', () => {
   it('reports one row per claim_path', async () => {
     const { VerificationService } = await import('../services/VerificationService.js');
+    const { createVerdictStore } = await import('../adapters/ConfiguredVerdictStore.js');
     const roundId = '00000000-0000-0000-0000-0000000000aa';
     const service = new VerificationService({
-      dbRef: { pool: null },
-      memVerifications: new Map(),
-      memSubmissionIndex: new Map([
-        ['sub-1', { room_id: 'room-1', claims: [{ id: 'c1', term: attributed }] }]
-      ])
+      store: createVerdictStore({
+        dbRef: { pool: null },
+        verdicts: new Map(),
+        submissionIndex: new Map([
+          ['sub-1', { room_id: 'room-1', claims: [{ id: 'c1', term: attributed }] }]
+        ])
+      })
     });
 
     const base = {

--- a/server/test/claims.verdict.persist.test.js
+++ b/server/test/claims.verdict.persist.test.js
@@ -123,10 +123,13 @@ describe('verdict claim_path persistence', () => {
   // stopped — revisit if the SQL-only direction lands.
   it('refuses a verdict whose path names no node in the claim term', async () => {
     const { VerificationService } = await import('../services/VerificationService.js');
+    const { createVerdictStore } = await import('../adapters/ConfiguredVerdictStore.js');
     const service = new VerificationService({
-      dbRef: { pool },
-      memVerifications: new Map(),
-      memSubmissionIndex: new Map()
+      store: createVerdictStore({
+        dbRef: { pool },
+        verdicts: new Map(),
+        submissionIndex: new Map()
+      })
     });
 
     await expect(
@@ -145,10 +148,13 @@ describe('verdict claim_path persistence', () => {
 
   it('accepts a path that does resolve against the stored term', async () => {
     const { VerificationService } = await import('../services/VerificationService.js');
+    const { createVerdictStore } = await import('../adapters/ConfiguredVerdictStore.js');
     const service = new VerificationService({
-      dbRef: { pool },
-      memVerifications: new Map(),
-      memSubmissionIndex: new Map()
+      store: createVerdictStore({
+        dbRef: { pool },
+        verdicts: new Map(),
+        submissionIndex: new Map()
+      })
     });
 
     const result = await service.submitVerdict({

--- a/server/test/e2e.claim.term.flow.test.js
+++ b/server/test/e2e.claim.term.flow.test.js
@@ -64,7 +64,8 @@ for (const mode of MODES) {
       await pool.query('delete from rooms where id = $1', [roomId]);
       await pool.query('insert into rooms(id, title) values ($1,$2)', [roomId, 'E2E Room']);
       await pool.query(
-        "insert into rounds(id, room_id, idx, phase, submit_deadline_unix) values ($1,$2,0,'submit',$3)",
+        `insert into rounds(id, room_id, idx, phase, submit_deadline_unix, published_at_unix)
+         values ($1,$2,0,'published',$3,extract(epoch from now())::bigint)`,
         [roundId, roomId, Math.floor(Date.now() / 1000) + 3600]
       );
       await pool.query(

--- a/server/test/e2e.claim.term.flow.test.js
+++ b/server/test/e2e.claim.term.flow.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import pg from 'pg';
+import app, { __setDbPool } from '../rpc.js';
+
+// The whole feature, driven the way a client meets it: over HTTP, against a
+// real database, through the actual routes.
+//
+// Everything else in this area is tested a layer at a time — the validator, the
+// projection, the store contract. None of that proves the pieces are wired to
+// each other, and this session shipped two defects that only a run would have
+// caught: a route gate that could never fire, and a verifier UI reading a field
+// the cutover had removed.
+//
+// The claim under test is the motivating one from the spec:
+//   "the study says remote work reduces productivity"
+// The attribution at `$` and the proposition at `$.body` are different findings,
+// and a judge must be able to rule on them separately.
+
+const named = (name) => ({ kind: 'named', name });
+const PROPOSITION = {
+  kind: 'claim',
+  subject: named('remote_work'),
+  predicate: 'reduces',
+  object: 'productivity'
+};
+const ATTRIBUTED = {
+  kind: 'framed',
+  frame: { kind: 'attribution', source: named('the_study') },
+  body: PROPOSITION
+};
+
+const dbUrl =
+  process.env.DB8_TEST_DATABASE_URL ||
+  process.env.DATABASE_URL ||
+  'postgresql://postgres:test@localhost:54329/db8_test';
+
+// Run against both persistence modes, for the same reason the VerdictStore
+// contract suite does: memory is a configured peer, not a lesser path, and a
+// flow that only works on one of them is a flow that breaks for half the rooms.
+const MODES = [
+  { name: 'memory', durable: false, enabled: true },
+  { name: 'durable', durable: true, enabled: Boolean(process.env.DB8_TEST_PG) }
+];
+
+for (const mode of MODES) {
+  const run = mode.enabled ? describe : describe.skip;
+
+  run(`end to end (${mode.name}): a structured claim, and a verdict on one of its nodes`, () => {
+    let pool;
+    const roomId = '9e2e0000-0000-0000-0000-000000000001';
+    const roundId = '9e2e0000-0000-0000-0000-000000000002';
+    const authorId = '9e2e0000-0000-0000-0000-000000000003';
+    const judgeId = '9e2e0000-0000-0000-0000-000000000004';
+
+    beforeAll(async () => {
+      if (!mode.durable) {
+        __setDbPool(null);
+        return;
+      }
+      pool = new pg.Pool({ connectionString: dbUrl });
+      __setDbPool(pool);
+
+      await pool.query('delete from rooms where id = $1', [roomId]);
+      await pool.query('insert into rooms(id, title) values ($1,$2)', [roomId, 'E2E Room']);
+      await pool.query(
+        "insert into rounds(id, room_id, idx, phase, submit_deadline_unix) values ($1,$2,0,'submit',$3)",
+        [roundId, roomId, Math.floor(Date.now() / 1000) + 3600]
+      );
+      await pool.query(
+        'insert into participants(id, room_id, anon_name, role) values ($1,$2,$3,$4), ($5,$2,$6,$7)',
+        [authorId, roomId, 'e2e_author', 'debater', judgeId, 'e2e_judge', 'judge']
+      );
+    });
+
+    afterAll(async () => {
+      if (!pool) return;
+      await pool.query('delete from rooms where id = $1', [roomId]);
+      __setDbPool(null);
+      await pool.end();
+    });
+
+    const submission = (term) => ({
+      room_id: roomId,
+      round_id: roundId,
+      author_id: authorId,
+      phase: 'submit',
+      deadline_unix: Math.floor(Date.now() / 1000) + 3600,
+      content: 'The evidence on remote work is contested.',
+      claims: [
+        { id: 'c1', term, support: [{ kind: 'citation', ref: 'https://example.com/study' }] }
+      ],
+      citations: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+      client_nonce: `e2e-${Math.random().toString(36).slice(2)}`
+    });
+
+    let submissionId;
+
+    it('accepts a submission carrying a structured claim term', async () => {
+      const res = await request(app)
+        .post('/rpc/submission.create')
+        .send(submission(ATTRIBUTED))
+        .expect(200);
+
+      expect(res.body.ok).toBe(true);
+      submissionId = res.body.submission_id;
+      expect(submissionId).toBeTruthy();
+    });
+
+    // The gate that was unreachable for the whole of the previous PR. A route
+    // that cannot produce its own documented error is not a gate.
+    it('rejects a malformed term with the documented error and the offending path', async () => {
+      const overDeep = (() => {
+        let t = PROPOSITION;
+        for (let i = 0; i < 20; i += 1) t = { kind: 'denial', body: t };
+        return t;
+      })();
+
+      const res = await request(app)
+        .post('/rpc/submission.create')
+        .send(submission(overDeep))
+        .expect(400);
+
+      expect(res.body.error).toBe('invalid_claim_term');
+      expect(res.body.details[0]).toMatchObject({ claim_id: 'c1', claim_index: 0 });
+      expect(res.body.details[0].message).toMatch(/nesting depth/);
+    });
+
+    it('rules on the attribution and the proposition as separate findings', async () => {
+      await request(app)
+        .post('/rpc/verify.submit')
+        .send({
+          round_id: roundId,
+          reporter_id: judgeId,
+          submission_id: submissionId,
+          claim_id: 'c1',
+          claim_path: '$',
+          verdict: 'false',
+          rationale: 'the study does not say that',
+          client_nonce: 'e2e-verdict-outer'
+        })
+        .expect(200);
+
+      await request(app)
+        .post('/rpc/verify.submit')
+        .send({
+          round_id: roundId,
+          reporter_id: judgeId,
+          submission_id: submissionId,
+          claim_id: 'c1',
+          claim_path: '$.body',
+          verdict: 'true',
+          rationale: 'the study says it, and it holds',
+          client_nonce: 'e2e-verdict-inner'
+        })
+        .expect(200);
+
+      const res = await request(app).get(`/verify/summary?round_id=${roundId}`).expect(200);
+      const mine = res.body.rows.filter((r) => r.submission_id === submissionId);
+
+      expect(mine.map((r) => r.claim_path).sort()).toEqual(['$', '$.body']);
+      // Opposite verdicts on one claim, which is the entire point: the
+      // attribution is false while the proposition it attributes is true.
+      expect(mine.find((r) => r.claim_path === '$').false_count).toBe(1);
+      expect(mine.find((r) => r.claim_path === '$.body').true_count).toBe(1);
+    });
+
+    it('refuses a verdict aimed at a node the claim does not have', async () => {
+      const res = await request(app)
+        .post('/rpc/verify.submit')
+        .send({
+          round_id: roundId,
+          reporter_id: judgeId,
+          submission_id: submissionId,
+          claim_id: 'c1',
+          claim_path: '$.parts[99].body',
+          verdict: 'false',
+          rationale: 'nowhere',
+          client_nonce: 'e2e-verdict-bogus'
+        })
+        .expect(400);
+
+      expect(res.body.error).toBe('claim_path_not_found');
+    });
+
+    it('refuses a path with no claim to anchor it', async () => {
+      await request(app)
+        .post('/rpc/verify.submit')
+        .send({
+          round_id: roundId,
+          reporter_id: judgeId,
+          submission_id: submissionId,
+          claim_path: '$.body',
+          verdict: 'false',
+          rationale: 'unanchored',
+          client_nonce: 'e2e-verdict-unanchored'
+        })
+        .expect(400);
+    });
+  });
+}

--- a/server/test/verdict.store.contract.test.js
+++ b/server/test/verdict.store.contract.test.js
@@ -72,8 +72,14 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (!pool) return;
-  await pool.query('delete from rooms where id = $1', [seed.roomId]);
-  await pool.end();
+  // Guarded separately: if beforeAll threw after the pool was made but before
+  // the fixture finished, `seed` is undefined and cleaning up would raise a
+  // TypeError that buries the fixture error which actually caused the failure.
+  try {
+    if (seed) await pool.query('delete from rooms where id = $1', [seed.roomId]);
+  } finally {
+    await pool.end();
+  }
 });
 
 const adapters = [
@@ -174,6 +180,38 @@ for (const adapter of adapters) {
       expect(inner.true_count).toBeGreaterThanOrEqual(1);
     });
 
+    // The port declares idempotency on (round, reporter, submission, claim, path,
+    // nonce). The nonce is what distinguishes a repeat from a revision: a judge
+    // who reconsiders sends the same tuple with a new nonce, and losing that
+    // silently discards their revised ruling.
+    //
+    // The previous idempotency test used one nonce for both calls, so it could
+    // not tell the two adapters apart. They disagreed.
+    it('treats a new nonce on the same tuple as a distinct verdict', async () => {
+      const shared = {
+        claim_path: '$',
+        claim_id: 'c1'
+      };
+      const first = await store.submitVerdict(
+        verdictInput({ ...shared, verdict: 'false', client_nonce: uniqueNonce() })
+      );
+      const revised = await store.submitVerdict(
+        verdictInput({ ...shared, verdict: 'true', client_nonce: uniqueNonce() })
+      );
+      expect(revised.id).not.toBe(first.id);
+    });
+
+    // Postgres cannot produce a row where total exceeds the four columns —
+    // verify_submit constrains the verdict value — so the memory adapter must
+    // not either.
+    it('keeps total equal to the sum of the counted columns', async () => {
+      await store.submitVerdict(verdictInput({ client_nonce: uniqueNonce() }));
+      for (const row of await store.summary(ids.roundId)) {
+        const counted = row.true_count + row.false_count + row.unclear_count + row.needs_work_count;
+        expect(counted, `total ${row.total} vs columns ${counted}`).toBe(row.total);
+      }
+    });
+
     it('returns summary rows carrying every counted field', async () => {
       await store.submitVerdict(verdictInput({ client_nonce: uniqueNonce() }));
       const [row] = await store.summary(ids.roundId);
@@ -192,15 +230,20 @@ for (const adapter of adapters) {
     });
 
     it('orders summary rows by submission, claim, then path', async () => {
-      const rows = await store.summary(ids.roundId);
-      const keys = rows.map((r) => [r.submission_id, r.claim_id || '', r.claim_path || '']);
-      const sorted = [...keys].sort(
-        (a, b) =>
-          String(a[0]).localeCompare(String(b[0])) ||
-          a[1].localeCompare(b[1]) ||
-          a[2].localeCompare(b[2])
+      // Asserted against an explicit expectation rather than by re-sorting the
+      // adapter's own output with the adapter's own comparator, which for the
+      // memory adapter could not fail whatever it returned.
+      await store.submitVerdict(
+        verdictInput({ claim_path: '$.body', client_nonce: uniqueNonce() })
       );
-      expect(keys).toEqual(sorted);
+      await store.submitVerdict(verdictInput({ claim_path: '$', client_nonce: uniqueNonce() }));
+
+      const paths = (await store.summary(ids.roundId))
+        .filter((r) => r.submission_id === ids.submissionId && r.claim_path)
+        .map((r) => r.claim_path);
+
+      // '$' sorts before '$.body': shorter prefix first.
+      expect(paths).toEqual(['$', '$.body']);
     });
 
     it('returns nothing for a round with no verdicts', async () => {

--- a/server/test/verdict.store.contract.test.js
+++ b/server/test/verdict.store.contract.test.js
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { MemoryVerdictStore } from '../adapters/MemoryVerdictStore.js';
+import { PostgresVerdictStore } from '../adapters/PostgresVerdictStore.js';
+import { VERDICT_STORE_METHODS } from '../ports/VerdictStore.js';
+
+// One contract, every adapter.
+//
+// This is the mechanism the codebase was missing. verify_summary grouped by
+// claim_path and the in-memory aggregate did not, so the same room reported
+// different findings depending on which adapter answered — and no test could
+// have caught it, because each adapter was only ever exercised on its own.
+//
+// A behaviour asserted once and executed N times is the point. Adding an
+// adapter means adding a row to `adapters`, not a parallel test file.
+
+const named = (name) => ({ kind: 'named', name });
+const TERM = {
+  kind: 'framed',
+  frame: { kind: 'attribution', source: named('the_study') },
+  body: {
+    kind: 'claim',
+    subject: named('remote_work'),
+    predicate: 'reduces',
+    object: 'productivity'
+  }
+};
+
+const dbUrl =
+  process.env.DB8_TEST_DATABASE_URL ||
+  process.env.DATABASE_URL ||
+  'postgresql://postgres:test@localhost:54329/db8_test';
+
+// The durable adapter needs a server. Without one the memory adapter is still
+// held to the contract, and the run says plainly that the other was skipped.
+const durableEnabled = Boolean(process.env.DB8_TEST_PG);
+
+let pool;
+let seed;
+
+beforeAll(async () => {
+  if (!durableEnabled) return;
+  pool = new pg.Pool({ connectionString: dbUrl });
+
+  // Fixtures the Postgres adapter needs to satisfy its foreign keys. The memory
+  // adapter needs only the submission index, so each adapter's `setup` below
+  // returns the ids its own store was primed with.
+  const roomId = '7c0a0000-0000-0000-0000-000000000001';
+  const roundId = '7c0a0000-0000-0000-0000-000000000002';
+  const authorId = '7c0a0000-0000-0000-0000-000000000003';
+  const reporterId = '7c0a0000-0000-0000-0000-000000000004';
+
+  await pool.query('delete from rooms where id = $1', [roomId]);
+  await pool.query('insert into rooms(id, title) values ($1, $2)', [roomId, 'Contract Room']);
+  await pool.query(
+    "insert into rounds(id, room_id, idx, phase, published_at_unix) values ($1, $2, 0, 'published', extract(epoch from now())::bigint)",
+    [roundId, roomId]
+  );
+  await pool.query(
+    'insert into participants(id, room_id, anon_name, role) values ($1,$2,$3,$4), ($5,$2,$6,$7)',
+    [authorId, roomId, 'contract_author', 'debater', reporterId, 'contract_judge', 'judge']
+  );
+  const claims = [{ id: 'c1', term: TERM, support: [{ kind: 'logic', ref: 'x' }] }];
+  const sub = await pool.query(
+    `insert into submissions (round_id, author_id, content, claims, canonical_sha256, client_nonce)
+     values ($1,$2,$3,$4,$5,$6) returning id`,
+    [roundId, authorId, 'contested', JSON.stringify(claims), 'c'.repeat(64), 'nonce-contract']
+  );
+
+  seed = { roomId, roundId, reporterId, submissionId: sub.rows[0].id };
+});
+
+afterAll(async () => {
+  if (!pool) return;
+  await pool.query('delete from rooms where id = $1', [seed.roomId]);
+  await pool.end();
+});
+
+const adapters = [
+  {
+    name: 'memory',
+    enabled: () => true,
+    make: () => {
+      const submissionId = 'sub-contract';
+      const submissionIndex = new Map([
+        [submissionId, { room_id: 'room-1', claims: [{ id: 'c1', term: TERM }] }]
+      ]);
+      return {
+        store: new MemoryVerdictStore({ verdicts: new Map(), submissionIndex }),
+        ids: {
+          roundId: '00000000-0000-0000-0000-0000000000c1',
+          reporterId: '00000000-0000-0000-0000-0000000000c2',
+          submissionId
+        }
+      };
+    }
+  },
+  {
+    name: 'postgres',
+    enabled: () => durableEnabled,
+    make: () => ({
+      store: new PostgresVerdictStore({ dbRef: { pool } }),
+      ids: {
+        roundId: seed.roundId,
+        reporterId: seed.reporterId,
+        submissionId: seed.submissionId
+      }
+    })
+  }
+];
+
+for (const adapter of adapters) {
+  const run = adapter.enabled() ? describe : describe.skip;
+
+  run(`VerdictStore contract — ${adapter.name}`, () => {
+    let store;
+    let ids;
+    let nonce = 0;
+    const uniqueNonce = () => `contract-${adapter.name}-${(nonce += 1)}`;
+
+    beforeAll(() => {
+      const built = adapter.make();
+      store = built.store;
+      ids = built.ids;
+    });
+
+    const verdictInput = (over = {}) => ({
+      round_id: ids.roundId,
+      reporter_id: ids.reporterId,
+      submission_id: ids.submissionId,
+      claim_id: 'c1',
+      verdict: 'false',
+      rationale: 'because',
+      client_nonce: uniqueNonce(),
+      ...over
+    });
+
+    it('presents the whole port surface', () => {
+      for (const method of VERDICT_STORE_METHODS) {
+        expect(typeof store[method], method).toBe('function');
+      }
+    });
+
+    it('records a verdict and returns an id', async () => {
+      const { id } = await store.submitVerdict(verdictInput());
+      expect(id).toBeTruthy();
+    });
+
+    it('is idempotent for the same tuple and nonce', async () => {
+      const input = verdictInput({ client_nonce: uniqueNonce() });
+      const first = await store.submitVerdict(input);
+      const second = await store.submitVerdict(input);
+      expect(second.id).toBe(first.id);
+    });
+
+    it('treats a different claim_path as a different finding', async () => {
+      const roundId = ids.roundId;
+      await store.submitVerdict(
+        verdictInput({ claim_path: '$', verdict: 'false', client_nonce: uniqueNonce() })
+      );
+      await store.submitVerdict(
+        verdictInput({ claim_path: '$.body', verdict: 'true', client_nonce: uniqueNonce() })
+      );
+
+      const rows = (await store.summary(roundId)).filter(
+        (r) => r.submission_id === ids.submissionId && r.claim_path
+      );
+      const paths = rows.map((r) => r.claim_path).sort();
+      expect(paths).toEqual(['$', '$.body']);
+
+      const outer = rows.find((r) => r.claim_path === '$');
+      const inner = rows.find((r) => r.claim_path === '$.body');
+      expect(outer.false_count).toBeGreaterThanOrEqual(1);
+      expect(inner.true_count).toBeGreaterThanOrEqual(1);
+    });
+
+    it('returns summary rows carrying every counted field', async () => {
+      await store.submitVerdict(verdictInput({ client_nonce: uniqueNonce() }));
+      const [row] = await store.summary(ids.roundId);
+      for (const field of [
+        'submission_id',
+        'claim_id',
+        'claim_path',
+        'true_count',
+        'false_count',
+        'unclear_count',
+        'needs_work_count',
+        'total'
+      ]) {
+        expect(row, field).toHaveProperty(field);
+      }
+    });
+
+    it('orders summary rows by submission, claim, then path', async () => {
+      const rows = await store.summary(ids.roundId);
+      const keys = rows.map((r) => [r.submission_id, r.claim_id || '', r.claim_path || '']);
+      const sorted = [...keys].sort(
+        (a, b) =>
+          String(a[0]).localeCompare(String(b[0])) ||
+          a[1].localeCompare(b[1]) ||
+          a[2].localeCompare(b[2])
+      );
+      expect(keys).toEqual(sorted);
+    });
+
+    it('returns nothing for a round with no verdicts', async () => {
+      expect(await store.summary('00000000-0000-0000-0000-00000000dead')).toEqual([]);
+    });
+
+    it('reads back the stored term of a claim', async () => {
+      const term = await store.claimTerm(ids.submissionId, 'c1');
+      expect(term).toBeTruthy();
+      expect(term.kind).toBe('framed');
+      expect(term.body.predicate).toBe('reduces');
+    });
+
+    it('returns undefined for a claim id the submission does not have', async () => {
+      expect(await store.claimTerm(ids.submissionId, 'no-such-claim')).toBeUndefined();
+    });
+  });
+}

--- a/server/test/verify.durability.test.js
+++ b/server/test/verify.durability.test.js
@@ -60,7 +60,7 @@ describe('a configured database that fails does not silently degrade', () => {
     expect(verdicts.size).toBe(0);
   });
 
-  it('surfaces the failure for a path verdict the same way', async () => {
+  it('surfaces the failure from the claim-term lookup a path verdict performs', async () => {
     const service = new VerificationService({
       store: createVerdictStore({
         dbRef: { pool: failingPool() },
@@ -72,6 +72,32 @@ describe('a configured database that fails does not silently degrade', () => {
     await expect(service.submitVerdict(verdict({ claim_path: '$.body' }))).rejects.toThrow(
       /database_unavailable/
     );
+  });
+
+  // The case above never reaches the write: assertPathResolves calls claimTerm
+  // first and that is what fails. This one lets the lookup succeed so the
+  // failure has to come from submitVerdict itself.
+  it('surfaces the failure from the write when the lookup succeeded', async () => {
+    let call = 0;
+    const pool = {
+      query: async () => {
+        call += 1;
+        if (call === 1) return { rows: [{ term: TERM }] };
+        throw new Error('connection reset');
+      }
+    };
+    const service = new VerificationService({
+      store: createVerdictStore({
+        dbRef: { pool },
+        verdicts: new Map(),
+        submissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      })
+    });
+
+    await expect(service.submitVerdict(verdict({ claim_path: '$.body' }))).rejects.toThrow(
+      /database_unavailable/
+    );
+    expect(call, 'the write should have been attempted').toBe(2);
   });
 
   it('surfaces the failure on the summary read too', async () => {
@@ -222,14 +248,17 @@ describe('a rule the database enforced is not an outage', () => {
       }
     });
 
+  // Asserted on identity, not the message: a replacement error carrying the same
+  // text would pass while losing `code`, `severity`, and everything a caller
+  // needs to tell one rejection from another.
   it('surfaces a business rule rejection unchanged', async () => {
-    const store = storeWith(serverError('round_not_verifiable', '22023'));
-    await expect(store.submitVerdict({})).rejects.toThrow(/round_not_verifiable/);
+    const original = serverError('round_not_verifiable', '22023');
+    await expect(storeWith(original).submitVerdict({})).rejects.toBe(original);
   });
 
   it('surfaces a permission rejection unchanged', async () => {
-    const store = storeWith(serverError('reporter_role_denied', '42501'));
-    await expect(store.submitVerdict({})).rejects.toThrow(/reporter_role_denied/);
+    const original = serverError('reporter_role_denied', '42501');
+    await expect(storeWith(original).submitVerdict({})).rejects.toBe(original);
   });
 
   it('still reports a genuine connection failure as unavailable', async () => {

--- a/server/test/verify.durability.test.js
+++ b/server/test/verify.durability.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { VerificationService } from '../services/VerificationService.js';
 import { createVerdictStore } from '../adapters/ConfiguredVerdictStore.js';
+import { PostgresVerdictStore } from '../adapters/PostgresVerdictStore.js';
 import { VerifySubmit } from '../schemas.js';
 
 // A configured database that fails is a durability failure, not an invitation to
@@ -192,5 +193,54 @@ describe('the in-memory verdict key survives a colon in claim_id', () => {
     expect(rows.map((r) => r.claim_path).sort()).toEqual(['$', '$.body']);
     expect(rows.find((r) => r.claim_path === '$').false_count).toBe(1);
     expect(rows.find((r) => r.claim_path === '$.body').true_count).toBe(1);
+  });
+});
+
+describe('a rule the database enforced is not an outage', () => {
+  // The fail-loudly wrapper turned every Postgres error into
+  // database_unavailable, so verify_submit raising `round_not_verifiable` came
+  // back to the client as 503 Service Unavailable. The database answered
+  // perfectly well; it said no. Only a real run surfaced this.
+  //
+  // Server-side errors carry a SQLSTATE and a severity because Postgres replied.
+  // Connection failures carry neither.
+  const serverError = (message, code) => {
+    const err = new Error(message);
+    err.severity = 'ERROR';
+    err.code = code;
+    return err;
+  };
+
+  const storeWith = (err) =>
+    new PostgresVerdictStore({
+      dbRef: {
+        pool: {
+          query: async () => {
+            throw err;
+          }
+        }
+      }
+    });
+
+  it('surfaces a business rule rejection unchanged', async () => {
+    const store = storeWith(serverError('round_not_verifiable', '22023'));
+    await expect(store.submitVerdict({})).rejects.toThrow(/round_not_verifiable/);
+  });
+
+  it('surfaces a permission rejection unchanged', async () => {
+    const store = storeWith(serverError('reporter_role_denied', '42501'));
+    await expect(store.submitVerdict({})).rejects.toThrow(/reporter_role_denied/);
+  });
+
+  it('still reports a genuine connection failure as unavailable', async () => {
+    const err = new Error('connect ECONNREFUSED 127.0.0.1:54329');
+    err.code = 'ECONNREFUSED';
+    await expect(storeWith(err).submitVerdict({})).rejects.toThrow(/database_unavailable/);
+  });
+
+  it('treats an error with no severity as unavailable', async () => {
+    await expect(storeWith(new Error('Connection terminated')).submitVerdict({})).rejects.toThrow(
+      /database_unavailable/
+    );
   });
 });

--- a/server/test/verify.durability.test.js
+++ b/server/test/verify.durability.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { VerificationService } from '../services/VerificationService.js';
 import { createVerdictStore } from '../adapters/ConfiguredVerdictStore.js';
 import { PostgresVerdictStore } from '../adapters/PostgresVerdictStore.js';
+import { MemoryVerdictStore } from '../adapters/MemoryVerdictStore.js';
 import { VerifySubmit } from '../schemas.js';
 
 // A configured database that fails is a durability failure, not an invitation to
@@ -271,5 +272,52 @@ describe('a rule the database enforced is not an outage', () => {
     await expect(storeWith(new Error('Connection terminated')).submitVerdict({})).rejects.toThrow(
       /database_unavailable/
     );
+  });
+});
+
+describe('memory mode refuses new verdicts at capacity rather than evicting', () => {
+  // Eviction is not an option: dropping an older verdict makes the summary
+  // report fewer findings than were filed, silently. But an unbounded store is
+  // not an option either — client_nonce mints a new identity, so a client
+  // sending valid revisions can grow it until the process dies.
+  //
+  // So it fills up and says so, which is the same choice made for a database
+  // that cannot be reached: refuse the write rather than pretend.
+  const store = (capacity) =>
+    new MemoryVerdictStore({
+      verdicts: new Map(),
+      submissionIndex: indexWith([{ id: 'c1', term: TERM }]),
+      capacity
+    });
+
+  const at = (n) => ({ ...verdict(), client_nonce: `cap-${n}` });
+
+  it('accepts up to capacity', async () => {
+    const s = store(3);
+    for (let i = 0; i < 3; i += 1) expect((await s.submitVerdict(at(i))).id).toBeTruthy();
+  });
+
+  it('refuses the write that would exceed it', async () => {
+    const s = store(3);
+    for (let i = 0; i < 3; i += 1) await s.submitVerdict(at(i));
+    await expect(s.submitVerdict(at(99))).rejects.toThrow(/verdict_capacity_reached/);
+  });
+
+  // A repeat is not a new identity, so it must keep working: refusing it would
+  // break idempotency for a client retrying after a timeout.
+  it('still answers a repeat of an existing verdict when full', async () => {
+    const s = store(3);
+    const inputs = [at(0), at(1), at(2)];
+    for (const i of inputs) await s.submitVerdict(i);
+    const again = await s.submitVerdict(inputs[0]);
+    expect(again.id).toBeTruthy();
+  });
+
+  it('keeps every recorded verdict visible in the summary', async () => {
+    const s = store(3);
+    for (let i = 0; i < 3; i += 1) await s.submitVerdict(at(i));
+    await expect(s.submitVerdict(at(99))).rejects.toThrow();
+    const rows = await s.summary(verdict().round_id);
+    expect(rows.reduce((n, r) => n + r.total, 0)).toBe(3);
   });
 });

--- a/server/test/verify.durability.test.js
+++ b/server/test/verify.durability.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { VerificationService } from '../services/VerificationService.js';
+import { createVerdictStore } from '../adapters/ConfiguredVerdictStore.js';
 import { VerifySubmit } from '../schemas.js';
 
 // A configured database that fails is a durability failure, not an invitation to
@@ -44,22 +45,27 @@ function failingPool(message = 'connection reset') {
 
 describe('a configured database that fails does not silently degrade', () => {
   it('surfaces the failure instead of accepting the verdict into memory', async () => {
+    const verdicts = new Map();
     const service = new VerificationService({
-      dbRef: { pool: failingPool() },
-      memVerifications: new Map(),
-      memSubmissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      store: createVerdictStore({
+        dbRef: { pool: failingPool() },
+        verdicts,
+        submissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      })
     });
 
     await expect(service.submitVerdict(verdict())).rejects.toThrow(/database_unavailable/);
     // Nothing was written to the memory store on the way out.
-    expect(service.memVerifications.size).toBe(0);
+    expect(verdicts.size).toBe(0);
   });
 
   it('surfaces the failure for a path verdict the same way', async () => {
     const service = new VerificationService({
-      dbRef: { pool: failingPool() },
-      memVerifications: new Map(),
-      memSubmissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      store: createVerdictStore({
+        dbRef: { pool: failingPool() },
+        verdicts: new Map(),
+        submissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      })
     });
 
     await expect(service.submitVerdict(verdict({ claim_path: '$.body' }))).rejects.toThrow(
@@ -69,9 +75,11 @@ describe('a configured database that fails does not silently degrade', () => {
 
   it('surfaces the failure on the summary read too', async () => {
     const service = new VerificationService({
-      dbRef: { pool: failingPool() },
-      memVerifications: new Map(),
-      memSubmissionIndex: new Map()
+      store: createVerdictStore({
+        dbRef: { pool: failingPool() },
+        verdicts: new Map(),
+        submissionIndex: new Map()
+      })
     });
 
     await expect(service.getSummary('round-1')).rejects.toThrow(/database_unavailable/);
@@ -79,9 +87,11 @@ describe('a configured database that fails does not silently degrade', () => {
 
   it('still uses memory when no database is configured', async () => {
     const service = new VerificationService({
-      dbRef: { pool: null },
-      memVerifications: new Map(),
-      memSubmissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      store: createVerdictStore({
+        dbRef: { pool: null },
+        verdicts: new Map(),
+        submissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      })
     });
 
     const result = await service.submitVerdict(verdict());
@@ -92,9 +102,11 @@ describe('a configured database that fails does not silently degrade', () => {
 describe('a claim_path must be anchored to a claim that exists', () => {
   const service = () =>
     new VerificationService({
-      dbRef: { pool: null },
-      memVerifications: new Map(),
-      memSubmissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      store: createVerdictStore({
+        dbRef: { pool: null },
+        verdicts: new Map(),
+        submissionIndex: indexWith([{ id: 'c1', term: TERM }])
+      })
     });
 
   it('rejects a path whose claim_id names no claim in the submission', async () => {
@@ -155,9 +167,11 @@ describe('the in-memory verdict key survives a colon in claim_id', () => {
   // rows. Claim ids are author-supplied strings, not identifiers we mint.
   it('groups a colon-bearing claim id correctly', async () => {
     const service = new VerificationService({
-      dbRef: { pool: null },
-      memVerifications: new Map(),
-      memSubmissionIndex: indexWith([{ id: 'source:claim', term: TERM }])
+      store: createVerdictStore({
+        dbRef: { pool: null },
+        verdicts: new Map(),
+        submissionIndex: indexWith([{ id: 'source:claim', term: TERM }])
+      })
     });
 
     const roundId = '00000000-0000-0000-0000-0000000000a1';


### PR DESCRIPTION
The ports pilot, on the smallest service that already had the shape. Behaviour is unchanged — this exists to create the seam, and to prove the mechanism that was missing.

## What was wrong with the shape

`VerificationService` held the port, both adapters, and the selection logic in one body:

```js
constructor({ dbRef, memVerifications, memSubmissionIndex })
// ...then `if (this.pool)` in every method, with two implementations of each question
```

It now takes `{ store }` and holds only the rules that must hold whichever adapter answers. It no longer knows Postgres exists.

```
server/ports/VerdictStore.js             the contract, as documentation
server/adapters/PostgresVerdictStore.js  today's SQL, relocated
server/adapters/MemoryVerdictStore.js    today's memory logic, relocated
server/adapters/ConfiguredVerdictStore.js  selects by configuration
```

## Two decisions worth arguing with

**Path resolution stays *above* the port.** `server/claims/paths.js` owns the path grammar; resolving inside each adapter would be two implementations free to disagree. The store is asked only for the term — `claimTerm(submissionId, claimId)` — and the service decides whether the path names a node. Domain logic in the core, persistence behind the port.

**The selector routes on configuration, never on failure.** A configured database that errors still raises `database_unavailable` and the request fails. Memory is a peer chosen at composition, not a place requests land when Postgres misbehaves. Selection happens per call rather than at construction because `rpc.js` swaps the pool at runtime via `__setDbPool`, and a captured reference would keep using a replaced pool.

## The point of the exercise

One contract suite now runs against **every** adapter. This is the mechanism the codebase was missing, and its absence is exactly how the last bug shipped: `verify_summary` grouped by `claim_path` and the in-memory aggregate did not, so a room reported different findings depending on which adapter answered — and no test could have caught it, because each adapter was only ever exercised alone.

Reintroducing that exact defect now fails the suite:

```
× VerdictStore contract — memory > treats a different claim_path as a different finding
  → expected [] to deeply equal [ '$', '$.body' ]
```

Adding an adapter means adding a row to `adapters`, not writing a parallel test file. The durable adapter's cases skip with a plain message when no database is configured, so the memory adapter is still held to the contract on a database-less run.

## Deliberately unchanged

`note: 'db_fallback'` is preserved verbatim in the memory adapter's response even though the name is now a misnomer — memory is a configured mode, not a fallback. Renaming it is a response-shape change and does not belong in a refactor.

## Verification

- **285 passing, 0 failing** — 267 before this change, 267 after, plus 18 new contract tests
- Contract suite mutation-checked: reintroducing the historical bug turns it red
- `eslint`, `markdownlint`, `cspell`, `prettier --check .` all clean

## Next

The same silent-fallback shape remains in `AuthService`, `RoomService`, `ScoringService`, `SubmissionService` and `VoteService`. This PR proves the shape; replicating it is the follow-up, and the SQL-only direction then becomes a rewrite *inside* `PostgresVerdictStore` with the contract suite as an unchanged oracle.