### PR TITLE
fix(test): remove the DDL lock inversion behind the watcher flake

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -156,6 +156,8 @@
     "SQLSTATE",
     "resends",
     "setof",
+    "xact",
+    "hashtext",
     "unvalidated",
     "factive",
     "cutover"

--- a/scripts/prepare-db.js
+++ b/scripts/prepare-db.js
@@ -27,6 +27,9 @@ async function main() {
   const schemaPath = path.join(rootDir, 'db', 'schema.sql');
   const rpcPath = path.join(rootDir, 'db', 'rpc.sql');
   const rlsPath = path.join(rootDir, 'db', 'rls.sql');
+  // Applied here so no test file has to apply DDL at runtime. Each helper
+  // self-guards on a *_test database name.
+  const helpersPath = path.join(rootDir, 'db', 'test', 'helpers.sql');
 
   const client = new Client({ connectionString: dbUrl });
   await client.connect();
@@ -34,6 +37,7 @@ async function main() {
     if (await fileExists(schemaPath)) await applyFile(client, schemaPath);
     if (await fileExists(rpcPath)) await applyFile(client, rpcPath);
     if (await fileExists(rlsPath)) await applyFile(client, rlsPath);
+    if (await fileExists(helpersPath)) await applyFile(client, helpersPath);
   } finally {
     await client.end();
   }

--- a/server/test/e2e.claim.term.flow.test.js
+++ b/server/test/e2e.claim.term.flow.test.js
@@ -127,34 +127,39 @@ for (const mode of MODES) {
       expect(res.body.details[0].message).toMatch(/nesting depth/);
     });
 
-    it('rules on the attribution and the proposition as separate findings', async () => {
-      await request(app)
-        .post('/rpc/verify.submit')
-        .send({
-          round_id: roundId,
-          reporter_id: judgeId,
-          submission_id: submissionId,
-          claim_id: 'c1',
-          claim_path: '$',
-          verdict: 'false',
-          rationale: 'the study does not say that',
-          client_nonce: 'e2e-verdict-outer'
-        })
-        .expect(200);
+    // Asserted through a helper rather than .expect(200) so a failure reports the
+    // server's reason. A bare status assertion told us only "expected 200, got
+    // 400" when this flaked, which is not enough to diagnose anything.
+    const postVerdict = async (body, expected = 200) => {
+      const res = await request(app).post('/rpc/verify.submit').send(body);
+      expect(res.status, `verify.submit -> ${res.status}: ${JSON.stringify(res.body)}`).toBe(
+        expected
+      );
+      return res;
+    };
 
-      await request(app)
-        .post('/rpc/verify.submit')
-        .send({
-          round_id: roundId,
-          reporter_id: judgeId,
-          submission_id: submissionId,
-          claim_id: 'c1',
-          claim_path: '$.body',
-          verdict: 'true',
-          rationale: 'the study says it, and it holds',
-          client_nonce: 'e2e-verdict-inner'
-        })
-        .expect(200);
+    it('rules on the attribution and the proposition as separate findings', async () => {
+      await postVerdict({
+        round_id: roundId,
+        reporter_id: judgeId,
+        submission_id: submissionId,
+        claim_id: 'c1',
+        claim_path: '$',
+        verdict: 'false',
+        rationale: 'the study does not say that',
+        client_nonce: 'e2e-verdict-outer'
+      });
+
+      await postVerdict({
+        round_id: roundId,
+        reporter_id: judgeId,
+        submission_id: submissionId,
+        claim_id: 'c1',
+        claim_path: '$.body',
+        verdict: 'true',
+        rationale: 'the study says it, and it holds',
+        client_nonce: 'e2e-verdict-inner'
+      });
 
       const res = await request(app).get(`/verify/summary?round_id=${roundId}`).expect(200);
       const mine = res.body.rows.filter((r) => r.submission_id === submissionId);

--- a/server/test/rpc.sql.overloads.test.js
+++ b/server/test/rpc.sql.overloads.test.js
@@ -14,7 +14,7 @@ import path from 'node:path';
 // The test harness rebuilds from schema.sql every run, so a fresh database never
 // has the old function and cannot catch this. Only an upgrade can, which is what
 // this seeds.
-describe.sequential('rpc.sql leaves no stale function overloads', () => {
+describe('rpc.sql leaves no stale function overloads', () => {
   let pool;
   const dbUrl =
     process.env.DB8_TEST_DATABASE_URL ||
@@ -38,6 +38,11 @@ describe.sequential('rpc.sql leaves no stale function overloads', () => {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
+      // Serializes against any other runtime DDL applier. db/rpc.sql and
+      // db/rls.sql take rooms and rounds in opposite orders, so two appliers
+      // running concurrently deadlock. Anything added here that applies DDL
+      // must take this same lock.
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', ['db8:schema-ddl']);
 
       // Seed the shape an existing deployment would be carrying.
       await client.query(`

--- a/server/test/watcher.db.flip.test.js
+++ b/server/test/watcher.db.flip.test.js
@@ -1,7 +1,5 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { Pool } from 'pg';
-import fs from 'node:fs';
-import path from 'node:path';
 import { runTick } from '../watcher.js';
 
 const shouldRun = process.env.RUN_PGTAP === '1' || process.env.DB8_TEST_PG === '1';
@@ -15,12 +13,12 @@ suite('Watcher DB flips', () => {
   let roundId;
 
   beforeAll(async () => {
+    // No DDL here. db/rls.sql locks rooms before rounds; db/rpc.sql locks rounds
+    // before rooms. Applying either at runtime while another file applies the
+    // other deadlocks - an ABBA inversion, reproduced at roughly one run in
+    // five. The database is prepared once by `npm run test:prepare-db`, which
+    // now also applies db/test/helpers.sql.
     pool = new Pool({ connectionString: dbUrl });
-    // Always apply schema/RPC/RLS to keep isolated and deterministic
-    const rlsSql = fs.readFileSync(path.resolve('db/rls.sql'), 'utf8');
-    await pool.query(rlsSql);
-    const helpersSql = fs.readFileSync(path.resolve('db/test/helpers.sql'), 'utf8');
-    await pool.query(helpersSql);
   });
   afterAll(async () => {
     await pool.end();


### PR DESCRIPTION
## The flake had a mechanism, and it was mine

`watcher.db.flip.test.js` failed roughly one run in five with `error: deadlock detected`. Reproduced against a real server, not inferred:

```
Process 146 waits for AccessExclusiveLock on relation 16498 (rounds); blocked by 145.
Process 145 waits for AccessShareLock     on relation 16484 (rooms);  blocked by 146.
```

`db/rls.sql` locks in file order **rooms → participants → rounds**. `db/rpc.sql` takes **rounds** first (`CREATE VIEW view_current_round`) then **rooms** (`CREATE VIEW submissions_view … JOIN rooms`). Opposite order, same two relations, AccessShare against AccessExclusive, both held to commit — an ABBA cycle. Sweeping one session's start offset against the other, 5 of 25 offsets deadlocked, matching the observed rate.

Commit `3fb3b85` fixed the previous instance by stripping runtime schema application from the DB tests — **but left `rls.sql` in `watcher.db.flip`**. Harmless until `rpc.sql.overloads.test.js` (`11112ae`, mine) began applying all of `db/rpc.sql` inside a transaction and supplied the missing second party. A fresh regression, not an old flake.

## The fix

Stop applying DDL at runtime. `prepare-db.js` already applied `rls.sql`; it now also applies `db/test/helpers.sql`, which was the only part `watcher.db.flip` actually needed. Each helper self-guards on a `*_test` database name, and every entry point that runs the DB-gated suites calls `prepare-db` first. `helpers.sql` defines three test-only functions and overrides nothing in production, so applying it once globally is safe.

The one remaining runtime DDL applier takes a transaction-scoped advisory lock, so a future addition queues instead of deadlocking.

Also drops `describe.sequential` from `rpc.sql.overloads` — it orders suites *within* a file and says nothing about cross-file parallelism, which is where the collision was. It read as a guarantee it does not give.

## Rejected alternative

`--no-file-parallelism` was tried in #177, diagnosed wrong, and reverted six days ago. It costs roughly **5×** on every run (≈22–25s per pass serialised vs 4.2s) and would have left the inversion in the tree.

## A separate, unrelated flake — surfaced, not fixed

One pre-push run failed `e2e.claim.term.flow` (durable) with `expected 200, got 400`, and has not reproduced in **eight** subsequent full runs. A bare `.expect(200)` reported only the status, which is not enough to diagnose. That assertion now goes through a helper that puts the response body in the failure message, so the next occurrence names the rule that rejected it. Not a weakening — the same status is still required.

I am flagging this rather than claiming the suite is now flake-free.

## Verification

Eight consecutive full runs on this branch, **zero deadlocks**, 308 passing.