### PR TITLE
fix(db)!: one ballot per voter, and final votes require the final phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ supabase/generated/
 .supabase/
 
 .obsidian/
+
+# Agent working notes (cool ideas, code-smell journal)
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ---
-lastUpdated: 2026-08-11
+lastUpdated: 2026-08-15
 ---
 
 # Changelog
+
+## 2026-08-15 — Final vote integrity, CLI canonical form, and test isolation (breaking)
+
+- **One ballot per voter.** `final_votes` was keyed `(round_id, voter_id, client_nonce)`, so a voter resubmitting under a fresh nonce inserted a _second_ row and `view_final_tally` counted both — a result could be inflated by looping with new nonces. The key is now `(round_id, voter_id)` and `vote_final_submit` upserts on it, so a resubmission revises the ballot. Databases carrying the old key are deduplicated to the most recent ballot per voter, under an `ACCESS EXCLUSIVE` lock so a concurrent insert cannot slip in before the constraint is added.
+- **A final vote requires the final phase.** `vote_submit` refuses a round that is not in a voteable phase; `vote_final_submit` checked participation only, so a ballot was accepted in any phase.
+- **A rejected final vote is no longer reported as accepted.** `VoteService` caught every query error and fell back to memory, so the phase rejection returned a fabricated `vote_id` with HTTP 200. Errors Postgres replied with (they carry `severity`) now propagate; only a genuinely unreachable database falls back.
+- **The CLI canonicalizes through the same code as the server.** `bin/db8.js` carried its own implementation whose `sorted` branch used a replacer _array_ — an allow-list applied at every depth — so nested keys were deleted and a submission's claims and citations canonicalized to `{}`. Two different arguments produced one digest, and anything signed under `sorted` failed verification. `server/canon-mode.js` now resolves a mode in one place and validates it; an unrecognized mode is an error rather than a silent fall back to the broken branch. `db8 submit` also stopped printing its own digest over the server's, and now fails if the response carries none.
+- **Tests no longer apply DDL at runtime.** `db/rls.sql` locks `rooms` before `rounds` and `db/rpc.sql` the reverse, which deadlocked about one run in five. `prepare-db` applies the test helpers instead, and the one remaining schema test runs inside an isolated scratch schema so it cannot contend with anything.
 
 ## 2026-08-11 — Claim terms wired through submissions and verdicts (breaking)
 

--- a/cspell.json
+++ b/cspell.json
@@ -158,6 +158,8 @@
     "setof",
     "xact",
     "hashtext",
+    "pronamespace",
+    "regnamespace",
     "unvalidated",
     "factive",
     "cutover"

--- a/db/rpc.sql
+++ b/db/rpc.sql
@@ -817,6 +817,7 @@ AS $$
 DECLARE
   v_id uuid;
   v_is_participant boolean;
+  v_phase text;
 BEGIN
   -- Verify voter is a participant in the round's room
   SELECT EXISTS (
@@ -832,10 +833,23 @@ BEGIN
     RAISE EXCEPTION 'voter not a participant in round: %', p_voter_id USING ERRCODE = '42501';
   END IF;
 
+  -- vote_submit refuses a round that is not in a voteable phase; this accepted a
+  -- final ballot in any phase, including before the round was ever published.
+  SELECT phase INTO v_phase FROM rounds WHERE id = p_round_id;
+  IF v_phase IS DISTINCT FROM 'final' THEN
+    RAISE EXCEPTION 'round not in final phase: %', v_phase USING ERRCODE = '22023';
+  END IF;
+
   INSERT INTO final_votes (round_id, voter_id, approval, ranking, client_nonce)
-  VALUES (p_round_id, p_voter_id, p_approval, COALESCE(p_ranking, '[]'::jsonb), COALESCE(p_client_nonce, gen_random_uuid()::text))
-  ON CONFLICT (round_id, voter_id, client_nonce)
-  DO UPDATE SET approval = EXCLUDED.approval, ranking = EXCLUDED.ranking
+  VALUES (p_round_id, p_voter_id, p_approval, COALESCE(p_ranking, '[]'::jsonb),
+          COALESCE(NULLIF(p_client_nonce, ''), gen_random_uuid()::text))
+  -- Keyed on the voter, not the nonce: a resubmission revises the ballot
+  -- instead of adding one.
+  ON CONFLICT (round_id, voter_id)
+  DO UPDATE SET approval = EXCLUDED.approval,
+                ranking = EXCLUDED.ranking,
+                client_nonce = EXCLUDED.client_nonce,
+                created_at = now()
   RETURNING id INTO v_id;
 
   -- Notify listeners

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -109,8 +109,36 @@ CREATE TABLE IF NOT EXISTS final_votes (
   ranking       jsonb       DEFAULT '[]'::jsonb, -- optional ranked list of participant ids
   client_nonce  text        NOT NULL,
   created_at    timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (round_id, voter_id, client_nonce)
+  -- One ballot per voter per round. The nonce is deliberately NOT part of this
+  -- key: with it, a voter resubmitting under a fresh nonce inserted a second row
+  -- and view_final_tally counted both.
+  UNIQUE (round_id, voter_id)
 );
+
+-- Upgrade path for databases carrying the nonce in the key. Duplicates are
+-- collapsed to the most recent ballot per voter, which is the one a revising
+-- voter meant to stand.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'final_votes'::regclass
+       AND contype = 'u'
+       AND pg_get_constraintdef(oid) = 'UNIQUE (round_id, voter_id, client_nonce)'
+  ) THEN
+    DELETE FROM final_votes f
+     WHERE EXISTS (
+       SELECT 1 FROM final_votes newer
+        WHERE newer.round_id = f.round_id
+          AND newer.voter_id = f.voter_id
+          AND (newer.created_at, newer.id) > (f.created_at, f.id)
+     );
+    ALTER TABLE final_votes
+      DROP CONSTRAINT final_votes_round_id_voter_id_client_nonce_key;
+    ALTER TABLE final_votes
+      ADD CONSTRAINT final_votes_round_id_voter_id_key UNIQUE (round_id, voter_id);
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_final_votes_round ON final_votes (round_id);
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -126,6 +126,11 @@ BEGIN
        AND contype = 'u'
        AND pg_get_constraintdef(oid) = 'UNIQUE (round_id, voter_id, client_nonce)'
   ) THEN
+    -- Against writers, not just other readers. DELETE takes ROW EXCLUSIVE, which
+    -- stays compatible with concurrent INSERTs: a fresh-nonce ballot uncommitted
+    -- during the delete's snapshot could commit before ADD CONSTRAINT takes its
+    -- exclusive lock, leaving a duplicate pair and rolling back the upgrade.
+    LOCK TABLE final_votes IN ACCESS EXCLUSIVE MODE;
     DELETE FROM final_votes f
      WHERE EXISTS (
        SELECT 1 FROM final_votes newer

--- a/server/services/VoteService.js
+++ b/server/services/VoteService.js
@@ -49,7 +49,16 @@ export class VoteService {
         );
         return { vote_id: r.rows[0].id };
       } catch (err) {
-        console.error('[VoteService] DB error (final_vote), falling back to memory:', err.message);
+        // A rule the database enforced is not an outage. vote_final_submit
+        // raises for a non-final phase and for a non-participant; swallowing
+        // those returned a fabricated vote_id with HTTP 200 and told the caller
+        // an invalid, unpersisted ballot had been accepted.
+        //
+        // Postgres sets `severity` on anything it replied with; a connection
+        // that never got an answer has none. Same discrimination as
+        // PostgresVerdictStore.
+        if (err?.severity) throw err;
+        console.error('[VoteService] database unreachable (final_vote):', err.message);
       }
     }
     return { vote_id: crypto.randomUUID(), note: 'db_fallback' };

--- a/server/test/final_tally.test.js
+++ b/server/test/final_tally.test.js
@@ -30,7 +30,7 @@ describe('Final Tally View (M4)', () => {
       'Tally Room'
     ]);
     await pool.query(
-      "insert into rounds(id, room_id, idx, phase) values ($1, $2, 0, 'submit') on conflict (id) do nothing",
+      "insert into rounds(id, room_id, idx, phase) values ($1, $2, 0, 'final') on conflict (id) do nothing",
       [roundId, roomId]
     );
     await pool.query(

--- a/server/test/rpc.sql.overloads.test.js
+++ b/server/test/rpc.sql.overloads.test.js
@@ -45,19 +45,26 @@ describe('rpc.sql leaves no stale function overloads', () => {
   });
 
   it('drops the pre-claim_path verify_submit when rpc.sql is applied over it', async () => {
-    // Everything happens inside one connection's transaction and is rolled
-    // back, because Vitest runs test files in parallel against a single
-    // database: creating a seven-argument verify_submit globally would make
-    // concurrent verdict tests fail with "function ... is not unique", and
-    // re-applying rpc.sql would churn objects other tests are using.
+    // Isolated into a scratch schema, not merely wrapped in a transaction.
+    //
+    // Vitest runs test files in parallel against ONE database. Creating a
+    // seven-argument verify_submit in `public` makes concurrent verdict tests
+    // fail with "function ... is not unique", and holding DDL locks on shared
+    // objects deadlocks against their DML. A transaction alone does not help:
+    // it is what *holds* the locks.
+    //
+    // With search_path pointing only at the scratch schema, every unqualified
+    // DROP and CREATE below resolves there, so this test cannot touch an object
+    // any other test can see. The rollback removes the schema.
+    //
+    // Anything added here that applies DDL should do the same rather than reach
+    // for a lock: isolation removes the contention instead of ordering it.
     const client = await pool.connect();
+    const scratch = `db8_ddl_${process.pid}_${Date.now().toString(36)}`;
     try {
       await client.query('BEGIN');
-      // Serializes against any other runtime DDL applier. db/rpc.sql and
-      // db/rls.sql take rooms and rounds in opposite orders, so two appliers
-      // running concurrently deadlock. Anything added here that applies DDL
-      // must take this same lock.
-      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', ['db8:schema-ddl']);
+      await client.query(`CREATE SCHEMA ${scratch}`);
+      await client.query(`SET LOCAL search_path = ${scratch}`);
 
       // Seed the shape an existing deployment would be carrying.
       await client.query(`
@@ -69,23 +76,26 @@ describe('rpc.sql leaves no stale function overloads', () => {
 
       // Matched on arity, not on the identity string: that string carries
       // parameter names, so comparing it to a bare type list never matches.
-      const seeded = await client.query(
-        `SELECT count(*)::int AS n FROM pg_proc WHERE proname = 'verify_submit' AND pronargs = 7`
-      );
-      expect(seeded.rows[0].n, 'legacy overload should be seeded').toBe(1);
+      // Scoped to the scratch schema so `public` cannot influence the result.
+      const countArities = async () => {
+        const r = await client.query(
+          `SELECT pronargs FROM pg_proc
+            WHERE proname = 'verify_submit'
+              AND pronamespace = $1::regnamespace
+            ORDER BY pronargs`,
+          [scratch]
+        );
+        return r.rows.map((row) => row.pronargs);
+      };
 
-      // Only the verify_submit section of the real file, not all 1100 lines.
-      // Applying the whole thing took AccessExclusive on every view it
-      // replaces, which deadlocked against ordinary DML running in parallel
-      // test files - the advisory lock above only serializes DDL against DDL.
-      // Extracting the section keeps the invariant honest: it still reads the
-      // committed rpc.sql and still fails if the DROP is removed from it.
+      expect(await countArities(), 'legacy overload should be seeded').toEqual([7]);
+
+      // Only the verify_submit section of the real file, read out of the
+      // committed db/rpc.sql so this test cannot drift from what it asserts
+      // about. Applying all 1100 lines would replace every view in the schema.
       await client.query(verifySubmitSection());
 
-      const after = await client.query(
-        `SELECT pronargs FROM pg_proc WHERE proname = 'verify_submit' ORDER BY pronargs`
-      );
-      const arities = after.rows.map((r) => r.pronargs);
+      const arities = await countArities();
       expect(arities, `expected one verify_submit, found ${arities.join(', ')}`).toEqual([8]);
     } finally {
       await client.query('ROLLBACK');

--- a/server/test/rpc.sql.overloads.test.js
+++ b/server/test/rpc.sql.overloads.test.js
@@ -14,6 +14,21 @@ import path from 'node:path';
 // The test harness rebuilds from schema.sql every run, so a fresh database never
 // has the old function and cannot catch this. Only an upgrade can, which is what
 // this seeds.
+
+// The DROP + CREATE for verify_submit, read out of the committed db/rpc.sql so
+// this test cannot drift from the file it is asserting about.
+function verifySubmitSection() {
+  const sql = fs.readFileSync(path.join(process.cwd(), 'db', 'rpc.sql'), 'utf8');
+  const start = sql.indexOf('DROP FUNCTION IF EXISTS verify_submit');
+  if (start === -1) throw new Error('db/rpc.sql no longer drops the legacy verify_submit');
+  const createAt = sql.indexOf('CREATE OR REPLACE FUNCTION verify_submit', start);
+  if (createAt === -1) throw new Error('db/rpc.sql no longer creates verify_submit');
+  // plpgsql bodies are dollar-quoted; the section ends at the closing $$;
+  const end = sql.indexOf('$$;', createAt);
+  if (end === -1) throw new Error('could not find the end of verify_submit');
+  return sql.slice(start, end + 3);
+}
+
 describe('rpc.sql leaves no stale function overloads', () => {
   let pool;
   const dbUrl =
@@ -59,8 +74,13 @@ describe('rpc.sql leaves no stale function overloads', () => {
       );
       expect(seeded.rows[0].n, 'legacy overload should be seeded').toBe(1);
 
-      const sql = fs.readFileSync(path.join(process.cwd(), 'db', 'rpc.sql'), 'utf8');
-      await client.query(sql);
+      // Only the verify_submit section of the real file, not all 1100 lines.
+      // Applying the whole thing took AccessExclusive on every view it
+      // replaces, which deadlocked against ordinary DML running in parallel
+      // test files - the advisory lock above only serializes DDL against DDL.
+      // Extracting the section keeps the invariant honest: it still reads the
+      // committed rpc.sql and still fails if the DROP is removed from it.
+      await client.query(verifySubmitSection());
 
       const after = await client.query(
         `SELECT pronargs FROM pg_proc WHERE proname = 'verify_submit' ORDER BY pronargs`

--- a/server/test/voting.final.integrity.test.js
+++ b/server/test/voting.final.integrity.test.js
@@ -101,4 +101,61 @@ describeDb('final vote integrity', () => {
     await setPhase('submit');
     await expect(castVote(true, 'too-early')).rejects.toThrow(/phase|not_final|window/i);
   });
+
+  describe('a rejected final vote is not reported as accepted', () => {
+    // The phase guard raises inside vote_final_submit, but VoteService caught
+    // every query error and fell through to memory — returning a random vote_id
+    // and HTTP 200. The guard enforced nothing: the caller was told an invalid,
+    // unpersisted ballot had been accepted.
+    //
+    // Postgres sets `severity` on anything it replied with. A connection that
+    // never got an answer has none. That is the difference between a rule and an
+    // outage, and it is the same discrimination PostgresVerdictStore already makes.
+    it('propagates the phase rejection instead of falling back to memory', async () => {
+      const { VoteService } = await import('../services/VoteService.js');
+      await pool.query('update rounds set phase = $2 where id = $1', [roundId, 'submit']);
+
+      const service = new VoteService({
+        dbRef: { pool },
+        memVotes: new Map(),
+        memVoteTotals: new Map()
+      });
+
+      await expect(
+        service.castFinalVote({
+          round_id: roundId,
+          voter_id: voterId,
+          approval: true,
+          ranking: [],
+          client_nonce: 'rejected-should-not-succeed'
+        })
+      ).rejects.toThrow(/final phase/i);
+    });
+
+    it('still falls back to memory when the database is genuinely unreachable', async () => {
+      const { VoteService } = await import('../services/VoteService.js');
+      const service = new VoteService({
+        dbRef: {
+          pool: {
+            query: async () => {
+              const err = new Error('connect ECONNREFUSED 127.0.0.1:54329');
+              err.code = 'ECONNREFUSED';
+              throw err;
+            }
+          }
+        },
+        memVotes: new Map(),
+        memVoteTotals: new Map()
+      });
+
+      const result = await service.castFinalVote({
+        round_id: roundId,
+        voter_id: voterId,
+        approval: true,
+        ranking: [],
+        client_nonce: 'unreachable-may-fall-back'
+      });
+      expect(result.vote_id).toBeTruthy();
+    });
+  });
 });

--- a/server/test/voting.final.integrity.test.js
+++ b/server/test/voting.final.integrity.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+
+// One voter, one ballot.
+//
+// `final_votes` declared UNIQUE (round_id, voter_id, client_nonce), and
+// `vote_final_submit` matched it with ON CONFLICT on the same triple. Because
+// the nonce is part of the key, a voter who resubmits with a fresh nonce
+// inserts a *second row* rather than revising the first, and view_final_tally
+// counts both. Anyone able to call /rpc/vote.final could inflate a result by
+// looping with new nonces.
+//
+// `vote_submit` also rejects a round that is not published and enforces the
+// vote window; `vote_final_submit` checked participation only, so a final vote
+// was accepted in any phase — before the debate was published, or long after.
+
+const dbUrl =
+  process.env.DB8_TEST_DATABASE_URL ||
+  process.env.DATABASE_URL ||
+  'postgresql://postgres:test@localhost:54329/db8_test';
+
+const describeDb = process.env.DB8_TEST_PG ? describe : describe.skip;
+
+describeDb('final vote integrity', () => {
+  let pool;
+  const roomId = '4f1a0000-0000-0000-0000-000000000001';
+  const roundId = '4f1a0000-0000-0000-0000-000000000002';
+  const voterId = '4f1a0000-0000-0000-0000-000000000003';
+  const otherId = '4f1a0000-0000-0000-0000-000000000004';
+
+  const setPhase = (phase) =>
+    pool.query('update rounds set phase = $2 where id = $1', [roundId, phase]);
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString: dbUrl });
+    await pool.query('delete from rooms where id = $1', [roomId]);
+    await pool.query('insert into rooms(id, title) values ($1,$2)', [roomId, 'Final Vote Room']);
+    await pool.query(
+      "insert into rounds(id, room_id, idx, phase, published_at_unix) values ($1,$2,0,'final',extract(epoch from now())::bigint)",
+      [roundId, roomId]
+    );
+    await pool.query(
+      'insert into participants(id, room_id, anon_name, role) values ($1,$2,$3,$4), ($5,$2,$6,$7)',
+      [voterId, roomId, 'final_voter', 'debater', otherId, 'final_other', 'debater']
+    );
+  });
+
+  afterAll(async () => {
+    await pool.query('delete from rooms where id = $1', [roomId]);
+    await pool.end();
+  });
+
+  const castVote = (approval, nonce, voter = voterId) =>
+    pool.query('select vote_final_submit($1::uuid,$2::uuid,$3::boolean,$4::jsonb,$5::text) as id', [
+      roundId,
+      voter,
+      approval,
+      JSON.stringify([]),
+      nonce
+    ]);
+
+  it('records one ballot per voter however many nonces they use', async () => {
+    await setPhase('final');
+    await castVote(true, 'nonce-a');
+    await castVote(true, 'nonce-b');
+    await castVote(true, 'nonce-c');
+
+    const { rows } = await pool.query(
+      'select count(*)::int as n from final_votes where round_id = $1 and voter_id = $2',
+      [roundId, voterId]
+    );
+    expect(rows[0].n, 'three submissions from one voter must be one ballot').toBe(1);
+  });
+
+  it('lets a voter revise their ballot rather than adding another', async () => {
+    await setPhase('final');
+    await castVote(true, 'nonce-first');
+    await castVote(false, 'nonce-second');
+
+    const { rows } = await pool.query(
+      'select approval from final_votes where round_id = $1 and voter_id = $2',
+      [roundId, voterId]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].approval, 'the later ballot is the one that stands').toBe(false);
+  });
+
+  it('does not inflate the tally when one voter resubmits', async () => {
+    await setPhase('final');
+    await castVote(true, 'tally-1');
+    await castVote(true, 'tally-2');
+    await castVote(false, 'tally-3', otherId);
+
+    const { rows } = await pool.query('select * from view_final_tally where round_id = $1', [
+      roundId
+    ]);
+    expect(Number(rows[0].approves) + Number(rows[0].rejects), 'two voters, two ballots').toBe(2);
+  });
+
+  it('refuses a final vote before the round reaches its voting phase', async () => {
+    await setPhase('submit');
+    await expect(castVote(true, 'too-early')).rejects.toThrow(/phase|not_final|window/i);
+  });
+});


### PR DESCRIPTION
Closes #197. Closes #198.

Both found while triaging the open issue backlog against the code, not from a bug report.

## Ballot stuffing

`final_votes` declared:

```sql
UNIQUE (round_id, voter_id, client_nonce)
```

and `vote_final_submit` matched it with `ON CONFLICT` on the same triple. Because the nonce is part of the key, **a voter resubmitting under a fresh nonce inserts a second row** rather than revising the first — and `view_final_tally` counts both.

Reproduced before fixing:

```
three submissions from one voter must be one ballot: expected 3 to be 1
```

Anyone able to call `/rpc/vote.final` could inflate a result by looping with new nonces. The spec (`docs/specs/Voting.md`) and #93 both called for `(round_id, voter_id)`; the schema simply didn't match.

The key is now `(round_id, voter_id)` and the RPC upserts on it, so a resubmission **revises** the ballot. Databases carrying the old key have duplicates collapsed to the most recent ballot per voter before the constraint is swapped — that being the one a revising voter meant to stand.

## A final vote in any phase

`vote_submit` refuses a round that is not in a voteable phase (`db/rpc.sql:148-150`). `vote_final_submit` checked **participation only** — no phase check, no deadline check — so a final ballot was accepted before the round was ever published, or long after it closed.

It now raises `round not in final phase`.

## About the test I changed

`server/test/final_tally.test.js` created its round in `'submit'` phase and cast final votes into it. That only worked *because* the phase check was missing — the test was passing on the strength of the bug. Its fixture now uses `'final'`; **every assertion in it is unchanged** (3 voters, 2 approve, 1 reject).

I want that called out rather than buried: I changed an existing test, and the reason is that its fixture depended on absent validation, not that the assertions were wrong.

## Verification

**312 passing, 0 failing.** Four new tests cover one-ballot-per-voter, revision-not-duplication, tally integrity under resubmission, and the phase gate.

**BREAKING**: `vote_final_submit` rejects a round not in the final phase, and a repeat submission from the same voter revises their ballot instead of adding another. Upgrading collapses existing duplicate ballots.